### PR TITLE
Fix error in AttributeComponent

### DIFF
--- a/Runtime/Tags/AttributesComponent.cs
+++ b/Runtime/Tags/AttributesComponent.cs
@@ -48,7 +48,7 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// </summary>
         public event Action<string, float, float> OnAttributeModified;
 
-        private readonly Dictionary<string, Func<object, Attribute>> _attributeFieldGetters;
+        private Dictionary<string, Func<object, Attribute>> _attributeFieldGetters;
         private readonly HashSet<EffectHandle> _effectHandles;
 
         [SiblingComponent]
@@ -62,7 +62,6 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// </summary>
         protected AttributesComponent()
         {
-            _attributeFieldGetters = AttributeUtilities.GetOptimizedAttributeFields(GetType());
             _effectHandles = new HashSet<EffectHandle>();
         }
 
@@ -72,6 +71,7 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// </summary>
         protected virtual void Awake()
         {
+            EnsureAttributeFieldGettersInitialized();
             this.AssignSiblingComponents();
             _effectHandler.Register(this);
         }
@@ -217,8 +217,9 @@ namespace WallstopStudios.UnityHelpers.Tags
             }
         }
 
-        private bool TryGetAttribute(string attributeName, out Attribute attribute)
+        protected bool TryGetAttribute(string attributeName, out Attribute attribute)
         {
+            EnsureAttributeFieldGettersInitialized();
             if (
                 !_attributeFieldGetters.TryGetValue(
                     attributeName,
@@ -232,6 +233,16 @@ namespace WallstopStudios.UnityHelpers.Tags
 
             attribute = getter(this);
             return true;
+        }
+
+        protected void EnsureAttributeFieldGettersInitialized()
+        {
+            if (_attributeFieldGetters != null)
+            {
+                return;
+            }
+
+            _attributeFieldGetters = AttributeUtilities.GetOptimizedAttributeFields(GetType());
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.wallstop-studios.unity-helpers",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "displayName": "Unity Helpers",
   "description": "Various Unity Helper Library",
   "dependencies": {},


### PR DESCRIPTION
Fixes:

```
UnityException: LoadAll is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'AvatarStats' on game object 'Avatar'.
See "Script Serialization" page in the Unity Manual for further details.
UnityEngine.ResourcesAPIInternal.LoadAll (System.String path, System.Type systemTypeInstance) (at <7b8172fcdd864e17924794813da71712>:0)
UnityEngine.ResourcesAPI.LoadAll (System.String path, System.Type systemTypeInstance) (at <7b8172fcdd864e17924794813da71712>:0)
UnityEngine.Resources.LoadAll (System.String path, System.Type systemTypeInstance) (at <7b8172fcdd864e17924794813da71712>:0)
UnityEngine.Resources.LoadAll[T] (System.String path) (at <7b8172fcdd864e17924794813da71712>:0)
WallstopStudios.UnityHelpers.Utils.ScriptableObjectSingleton`1+<>c[T].<CreateLazy>b__3_0 () (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Utils/ScriptableObjectSingleton.cs:75)
System.Lazy`1[T].ViaFactory (System.Threading.LazyThreadSafetyMode mode) (at <59bd7c40c082431db25e1e728ab62789>:0)
System.Lazy`1[T].ExecutionAndPublication (System.LazyHelper executionAndPublication, System.Boolean useDefaultConstructor) (at <59bd7c40c082431db25e1e728ab62789>:0)
System.Lazy`1[T].CreateValue () (at <59bd7c40c082431db25e1e728ab62789>:0)
System.Lazy`1[T].get_Value () (at <59bd7c40c082431db25e1e728ab62789>:0)
WallstopStudios.UnityHelpers.Utils.ScriptableObjectSingleton`1[T].get_Instance () (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Utils/ScriptableObjectSingleton.cs:223)
WallstopStudios.UnityHelpers.Tags.AttributeUtilities+<>c.<GetOptimizedAttributeFields>b__17_0 (System.Type inputType) (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Tags/AttributeUtilities.cs:336)
WallstopStudios.UnityHelpers.Core.Extension.DictionaryExtensions.GetOrAdd[K,V] (System.Collections.Generic.IDictionary`2[TKey,TValue] dictionary, K key, System.Func`2[T,TResult] valueProducer) (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Core/Extension/DictionaryExtensions.cs:86)
WallstopStudios.UnityHelpers.Tags.AttributeUtilities.GetOptimizedAttributeFields (System.Type type) (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Tags/AttributeUtilities.cs:331)
WallstopStudios.UnityHelpers.Tags.AttributesComponent..ctor () (at ./Library/PackageCache/com.wallstop-studios.unity-helpers@9e97d97db408/Runtime/Tags/AttributesComponent.cs:65)
MB6.AvatarStats..ctor () (at Assets/_Project/Scripts/AvatarStats.cs:8)


AttributeMetadataCache: Exception during relational prewarm on load: LoadAll is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'AvatarStats' on game object 'Avatar'.
See "Script Serialization" page in the Unity Manual for further details.
UnityEngine.UnityException: LoadAll is not allowed to be called from a MonoBehaviour constructor (or instance field initializer), call it in Awake or Start instead. Called from MonoBehaviour 'AvatarStats' on game object 'Avatar'.
See "Script Serialization" page in the Unity Manual for further details.
  at (wrapper managed-to-native) UnityEngine.ResourcesAPIInternal.LoadAll_Injected(UnityEngine.Bindings.ManagedSpanWrapper&,System.Type)
  at UnityEngine.ResourcesAPIInternal.LoadAll (System.String path, System.Type systemTypeInstance) [0x00048] in <7b8172fcdd864e17924794813da71712>:0 
  at UnityEngine.ResourcesAPI.LoadAll (System.String path, System.Type systemTypeInstance) [0x00000] in <7b8172fcdd864e17924794813da71712>:0 
  at UnityEngine.Resources.LoadAll (System.String path, System.Type systemTypeInstance) [0x00006] in <7b8172fcdd864e17924794813da71712>:0 
  at UnityEngine.Resources.LoadAll[T] (System.String path) [0x00001] in <7b8172fcdd864e17924794813da71712>:0 
  at WallstopStudios.UnityHelpers.Utils.ScriptableObjectSingleton`1+<>c[T].<CreateLazy>b__3_0 () [0x00011] in .\Library\PackageCache\com.wallstop-studios.unity-helpers@9e97d97db408\Runtime\Utils\ScriptableObjectSingleton.cs:75 
  at System.Lazy`1[T].ViaFactory (System.Threading.LazyThreadSafetyMode mode) [0x0001c] in <59bd7c40c082431db25e1e728ab62789>:0 
--- End of stack trace from previous location where exception was thrown ---

  at System.LazyHelper.ThrowException () [0x00000] in <59bd7c40c082431db25e1e728ab62789>:0 
  at System.Lazy`1[T].CreateValue () [0x0007e] in <59bd7c40c082431db25e1e728ab62789>:0 
  at System.Lazy`1[T].get_Value () [0x0000a] in <59bd7c40c082431db25e1e728ab62789>:0 
  at WallstopStudios.UnityHelpers.Utils.ScriptableObjectSingleton`1[T].get_Instance () [0x00000] in .\Library\PackageCache\com.wallstop-studios.unity-helpers@9e97d97db408\Runtime\Utils\ScriptableObjectSingleton.cs:223 
  at WallstopStudios.UnityHelpers.Tags.AttributeMetadataCache.RuntimePrewarmRelationalIfEnabled () [0x00000] in .\Library\PackageCache\com.wallstop-studios.unity-helpers@9e97d97db408\Runtime\Tags\AttributeMetadataCache.cs:226 
UnityEngine.Debug:LogError (object)
```