### PR TITLE
Harden release pipeline

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -98,11 +98,7 @@ jobs:
           BUMP: ${{ inputs.bump }}
           EXPLICIT_VERSION: ${{ inputs.version }}
         run: |
-          $arguments = @('-Bump', $env:BUMP)
-          if (-not [string]::IsNullOrWhiteSpace($env:EXPLICIT_VERSION)) {
-            $arguments += @('-Version', $env:EXPLICIT_VERSION)
-          }
-          ./scripts/release-tools/prepare-release.ps1 @arguments
+          ./scripts/release-tools/prepare-release.ps1 -Bump $env:BUMP -Version $env:EXPLICIT_VERSION
 
       - name: Sync generated version references
         shell: pwsh

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -58,7 +58,8 @@ jobs:
                 message="Version ${version} is untagged and CHANGELOG.md documents it, "
                 message+="but head subject '${subject}' is not 'release: ${version}'. "
                 message+="Squash-merge release PRs with the default title, or tag this commit manually."
-                echo "::warning::${message}"
+                echo "::error::${message}"
+                exit 1
               fi
             else
               echo "Head commit is not a release commit; nothing to do."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,9 @@ jobs:
 
       - name: Verify downloaded artifacts
         id: artifacts
+        env:
+          EXPECTED_PACKAGE_NAME: ${{ needs.verify-tag.outputs.package-name }}
+          EXPECTED_PACKAGE_VERSION: ${{ needs.verify-tag.outputs.package-version }}
         run: |
           set -euo pipefail
           mapfile -t packages < <(find .artifacts/release -maxdepth 1 -type f -name '*.tgz' | sort)
@@ -252,6 +255,21 @@ jobs:
           unitypackage_file="${unitypackages[0]}"
           (cd "$(dirname "${package_file}")" && sha256sum -c "$(basename "${package_file}").sha256")
           (cd "$(dirname "${unitypackage_file}")" && sha256sum -c "$(basename "${unitypackage_file}").sha256")
+
+          notes_file=".artifacts/release/release-notes.md"
+          if [ ! -s "${notes_file}" ]; then
+            echo "::error::Release notes artifact is missing or empty: ${notes_file}."
+            exit 1
+          fi
+
+          package_manifest="$(tar -xOf "${package_file}" package/package.json)"
+          packed_name="$(printf '%s' "${package_manifest}" | jq -r '.name // empty')"
+          packed_version="$(printf '%s' "${package_manifest}" | jq -r '.version // empty')"
+          if [ "${packed_name}" != "${EXPECTED_PACKAGE_NAME}" ] || [ "${packed_version}" != "${EXPECTED_PACKAGE_VERSION}" ]; then
+            echo "::error::Npm tarball identity mismatch. Expected ${EXPECTED_PACKAGE_NAME}@${EXPECTED_PACKAGE_VERSION}; found ${packed_name}@${packed_version}."
+            exit 1
+          fi
+
           echo "package-file=${package_file}" >> "${GITHUB_OUTPUT}"
           echo "unitypackage-file=${unitypackage_file}" >> "${GITHUB_OUTPUT}"
 

--- a/scripts/tests/test-release-tools.ps1
+++ b/scripts/tests/test-release-tools.ps1
@@ -130,6 +130,29 @@ try {
     }
     Write-TestResult -TestName 'Explicit versions must increase' -Passed $nonIncreasingRejected
 
+    $fixture = New-ReleaseFixture
+    try {
+        $prepareScriptPath = Join-Path $repoRoot 'scripts/release-tools/prepare-release.ps1'
+        $prepareOutput = & pwsh -NoProfile -File $prepareScriptPath `
+            -RepoRoot $fixture `
+            -Bump minor `
+            -Version '' `
+            -Date '2026-06-30' *>&1
+        $prepareExitCode = $LASTEXITCODE
+        $packageJson = Get-Content -Path (Join-Path $fixture 'package.json') -Raw | ConvertFrom-Json
+        $changelog = Get-Content -Path (Join-Path $fixture 'CHANGELOG.md') -Raw
+        Write-TestResult `
+            -TestName 'Prepare release script accepts empty explicit version from workflow' `
+            -Passed (
+                $prepareExitCode -eq 0 -and
+                $packageJson.version -eq '1.3.0' -and
+                $changelog.Contains('## [1.3.0] - 2026-06-30')
+            ) `
+            -Message ($prepareOutput | Out-String)
+    } finally {
+        Remove-ReleaseFixture -Path $fixture
+    }
+
     $helperContent = Get-Content -Path (Join-Path $repoRoot 'scripts/release-tools/release-helpers.ps1') -Raw
     Write-TestResult `
         -TestName 'Package version rewrite uses unambiguous regex replace overload' `

--- a/scripts/tests/test-sync-script-contracts.ps1
+++ b/scripts/tests/test-sync-script-contracts.ps1
@@ -1371,7 +1371,9 @@ function Run-ReleasePackageContentContractTests {
     -VariableName 'packageContentRoots'
   $validatorKeepsPackOutputConcise = (
     $validatorContent.Contains('npm pack --json --pack-destination $tempDir') -and
+    $validatorContent.Contains('1> $packStdoutPath 2> $packStderrPath') -and
     $validatorContent.Contains('npm pack produced $($packSummary.filename)') -and
+    -not $validatorContent.Contains('2>&1 | Out-String') -and
     -not $validatorContent.Contains('npm pack output: $packOutput')
   )
   $missingValidatorRequiredEntries = @($requiredPackageFilesEntries | Where-Object { $_ -notin $validatorRequiredEntries })

--- a/scripts/tests/test-sync-script-contracts.ps1
+++ b/scripts/tests/test-sync-script-contracts.ps1
@@ -1034,6 +1034,13 @@ function Run-ReleaseWorkflowGitHubCliContractTests {
 
   $publishHasRepo = $workflowContent -match "(?ms)- name: Publish GitHub Release.*?env:.*?${repoEnvPattern}.*?run:"
   $verifyHasRepo = $workflowContent -match "(?ms)- name: Verify GitHub Release assets.*?env:.*?${repoEnvPattern}.*?run:"
+  $verifyDownloadedArtifactsChecksIdentity = (
+    $workflowContent.Contains('EXPECTED_PACKAGE_NAME: ${{ needs.verify-tag.outputs.package-name }}') -and
+    $workflowContent.Contains('EXPECTED_PACKAGE_VERSION: ${{ needs.verify-tag.outputs.package-version }}') -and
+    $workflowContent.Contains('notes_file=".artifacts/release/release-notes.md"') -and
+    $workflowContent.Contains('tar -xOf "${package_file}" package/package.json') -and
+    $workflowContent.Contains('Npm tarball identity mismatch.')
+  )
 
   Write-TestResult `
     -TestName 'release publish gh commands set repository context' `
@@ -1044,6 +1051,11 @@ function Run-ReleaseWorkflowGitHubCliContractTests {
     -TestName 'release asset verification gh commands set repository context' `
     -Passed $verifyHasRepo `
     -Message 'Expected Verify GitHub Release assets to set GH_REPO from github.repository.'
+
+  Write-TestResult `
+    -TestName 'release publish verifies downloaded artifact identity before publish' `
+    -Passed $verifyDownloadedArtifactsChecksIdentity `
+    -Message 'Expected Verify downloaded artifacts to require non-empty release notes and matching npm tarball package name/version.'
 }
 
 function Run-ReleasePublishWorkflowBudgetContractTests {
@@ -1123,6 +1135,11 @@ function Run-ReleasePrepareWorkflowContractTests {
     $branchPushIndex -ge 0 -and
     $notesIndex -lt $branchPushIndex
   )
+  $usesExplicitPrepareReleaseInvocation = (
+    $workflowContent.Contains('./scripts/release-tools/prepare-release.ps1 -Bump $env:BUMP -Version $env:EXPLICIT_VERSION') -and
+    -not $workflowContent.Contains('$arguments = @(') -and
+    -not $workflowContent.Contains('@arguments')
+  )
 
   Write-TestResult `
     -TestName 'release prepare checks existing release branches with robust git heads lookup' `
@@ -1138,6 +1155,11 @@ function Run-ReleasePrepareWorkflowContractTests {
     -TestName 'release prepare validates release notes before pushing branch' `
     -Passed $generatesNotesBeforePushingBranch `
     -Message 'Expected write-release-notes.ps1 to run before pushing release/X.Y.Z so failed note generation leaves no remote branch.'
+
+  Write-TestResult `
+    -TestName 'release prepare invokes prepare-release with explicit PowerShell parameters' `
+    -Passed $usesExplicitPrepareReleaseInvocation `
+    -Message 'Expected release-prepare.yml to avoid positional array splatting that can bind "-Bump" as the Bump value.'
 }
 
 function Run-ReleaseTagWorkflowContractTests {
@@ -1179,7 +1201,12 @@ function Run-ReleaseTagWorkflowContractTests {
   $subjectCheckIndex = $workflowContent.IndexOf('subject="$(git log -1 --format=%s)"', [StringComparison]::Ordinal)
   $nonReleaseExitIndex = $workflowContent.IndexOf('Head commit is not a release commit; nothing to do.', [StringComparison]::Ordinal)
   $existingTagNoOpIndex = $workflowContent.IndexOf('git show-ref --verify --quiet "refs/tags/${version}"', [StringComparison]::Ordinal)
-  $untaggedWarningIndex = $workflowContent.IndexOf('Version ${version} is untagged and CHANGELOG.md documents it', [StringComparison]::Ordinal)
+  $untaggedErrorIndex = $workflowContent.IndexOf('Version ${version} is untagged and CHANGELOG.md documents it', [StringComparison]::Ordinal)
+  $untaggedErrorExitIndex = if ($untaggedErrorIndex -ge 0) {
+    $workflowContent.IndexOf('exit 1', $untaggedErrorIndex, [StringComparison]::Ordinal)
+  } else {
+    -1
+  }
   $nonReleaseProceedFalseIndex = if ($subjectCheckIndex -ge 0) {
     $workflowContent.IndexOf('echo "proceed=false" >> "${GITHUB_OUTPUT}"', $subjectCheckIndex, [StringComparison]::Ordinal)
   } else {
@@ -1212,11 +1239,18 @@ function Run-ReleaseTagWorkflowContractTests {
     $tagLookupIndex -gt $releaseHeadingValidationIndex -and
     $tagMismatchIndex -gt $tagLookupIndex
   )
-  $checksLocalTagBeforeUntaggedWarning = (
+  $checksLocalTagBeforeUntaggedError = (
     $subjectCheckIndex -ge 0 -and
     $existingTagNoOpIndex -gt $subjectCheckIndex -and
-    $untaggedWarningIndex -gt $existingTagNoOpIndex -and
+    $untaggedErrorIndex -gt $existingTagNoOpIndex -and
+    $untaggedErrorExitIndex -gt $untaggedErrorIndex -and
+    $untaggedErrorExitIndex -lt $nonReleaseProceedFalseIndex -and
     $existingTagNoOpIndex -lt $nonReleaseProceedFalseIndex
+  )
+  $untaggedDocumentedVersionIsHardFailure = (
+    $checksLocalTagBeforeUntaggedError -and
+    $workflowContent.Contains('echo "::error::${message}"') -and
+    -not $workflowContent.Contains('echo "::warning::${message}"')
   )
   $fetchesTagsBeforeLocalTaggedNoOp = (
     $checkoutStepIndex -ge 0 -and
@@ -1255,9 +1289,9 @@ function Run-ReleaseTagWorkflowContractTests {
     -Message 'Expected release-tag.yml to treat tag lookup 404 as absent while failing auth, rate-limit, and other API errors.'
 
   Write-TestResult `
-    -TestName 'release tag workflow suppresses untagged warning for locally-known tags' `
-    -Passed $checksLocalTagBeforeUntaggedWarning `
-    -Message 'Expected release-tag.yml to check refs/tags/${version} before warning that the documented version is untagged.'
+    -TestName 'release tag workflow fails for untagged documented versions with non-release subjects' `
+    -Passed $untaggedDocumentedVersionIsHardFailure `
+    -Message 'Expected release-tag.yml to fail when CHANGELOG.md documents the package version, no local tag exists, and the commit subject is not a release subject.'
 
   Write-TestResult `
     -TestName 'release tag workflow fetches tags before local tagged no-op check' `
@@ -1335,6 +1369,11 @@ function Run-ReleasePackageContentContractTests {
   $validatorPackageContentRoots = Get-PowerShellSingleQuotedArrayEntries `
     -Content $validatorContent `
     -VariableName 'packageContentRoots'
+  $validatorKeepsPackOutputConcise = (
+    $validatorContent.Contains('npm pack --json --pack-destination $tempDir') -and
+    $validatorContent.Contains('npm pack produced $($packSummary.filename)') -and
+    -not $validatorContent.Contains('npm pack output: $packOutput')
+  )
   $missingValidatorRequiredEntries = @($requiredPackageFilesEntries | Where-Object { $_ -notin $validatorRequiredEntries })
   $requiredValidatorAllowedTopLevelEntries = @('scripts', 'scripts.meta')
   $missingValidatorAllowedTopLevelEntries = @($requiredValidatorAllowedTopLevelEntries | Where-Object { $_ -notin $validatorAllowedTopLevelEntries })
@@ -1375,6 +1414,11 @@ function Run-ReleasePackageContentContractTests {
     -TestName 'npm package validator requires all release package entries' `
     -Passed ($missingValidatorRequiredEntries.Count -eq 0) `
     -Message "Missing validator required entries: $($missingValidatorRequiredEntries -join ', ')"
+
+  Write-TestResult `
+    -TestName 'npm package validator keeps npm pack diagnostics concise' `
+    -Passed $validatorKeepsPackOutputConcise `
+    -Message 'Expected validate-npm-package.ps1 to avoid dumping the full npm pack file list during normal verbose validation.'
 
   Write-TestResult `
     -TestName 'npm package validator allows shipped scripts folder metadata' `

--- a/scripts/validate-npm-package.ps1
+++ b/scripts/validate-npm-package.ps1
@@ -115,11 +115,29 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
   # Step 2: Run npm pack
   Write-Info "Running npm pack..."
-  $packOutput = npm pack --json --pack-destination $tempDir 2>&1 | Out-String
+  $packStdoutPath = Join-Path $tempDir 'npm-pack.stdout.json'
+  $packStderrPath = Join-Path $tempDir 'npm-pack.stderr.log'
+  npm pack --json --pack-destination $tempDir 1> $packStdoutPath 2> $packStderrPath
   $packExitCode = $LASTEXITCODE
+  $packOutput = if (Test-Path -LiteralPath $packStdoutPath -PathType Leaf) {
+    Get-Content -LiteralPath $packStdoutPath -Raw
+  } else {
+    ''
+  }
+  $packErrorOutput = if (Test-Path -LiteralPath $packStderrPath -PathType Leaf) {
+    Get-Content -LiteralPath $packStderrPath -Raw
+  } else {
+    ''
+  }
+
   if ($packExitCode -ne 0) {
     Write-Error-Custom "npm pack failed with exit code $packExitCode."
-    Write-Host $packOutput
+    if (-not [string]::IsNullOrWhiteSpace($packOutput)) {
+      Write-Host $packOutput
+    }
+    if (-not [string]::IsNullOrWhiteSpace($packErrorOutput)) {
+      Write-Host $packErrorOutput
+    }
     exit $packExitCode
   }
 

--- a/scripts/validate-npm-package.ps1
+++ b/scripts/validate-npm-package.ps1
@@ -93,6 +93,19 @@ function Test-ExpectedPackageExclusion {
 }
 
 $repoRoot = (Get-Location).Path
+$packageJsonPath = Join-Path $repoRoot 'package.json'
+
+if (-not (Test-Path -LiteralPath $packageJsonPath -PathType Leaf)) {
+  Write-Error-Custom "package.json not found at $packageJsonPath"
+  exit 1
+}
+
+$packageJson = Get-Content -LiteralPath $packageJsonPath -Raw | ConvertFrom-Json
+$packageVersion = [string]$packageJson.version
+if ([string]::IsNullOrWhiteSpace($packageVersion)) {
+  Write-Error-Custom "package.json must define a non-empty version."
+  exit 1
+}
 
 # Step 1: Create a temporary directory for npm pack
 $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "npm-package-validation-$(Get-Random)"
@@ -102,8 +115,20 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 try {
   # Step 2: Run npm pack
   Write-Info "Running npm pack..."
-  $packOutput = npm pack --pack-destination $tempDir 2>&1 | Out-String
-  Write-Info "npm pack output: $packOutput"
+  $packOutput = npm pack --json --pack-destination $tempDir 2>&1 | Out-String
+  $packExitCode = $LASTEXITCODE
+  if ($packExitCode -ne 0) {
+    Write-Error-Custom "npm pack failed with exit code $packExitCode."
+    Write-Host $packOutput
+    exit $packExitCode
+  }
+
+  try {
+    $packSummary = @($packOutput | ConvertFrom-Json)[0]
+    Write-Info "npm pack produced $($packSummary.filename) with $($packSummary.files.Count) file(s)."
+  } catch {
+    Write-Info "npm pack completed."
+  }
 
   # Step 3: Find the tarball
   $tarball = Get-ChildItem -Path $tempDir -Filter "*.tgz" | Select-Object -First 1


### PR DESCRIPTION
## Summary
- fix the release-prepare workflow PowerShell invocation that bound `-Bump` as the bump value
- harden release publishing by verifying downloaded release notes and npm tarball identity before publish
- fail release-tag drift when CHANGELOG documents an untagged version on a non-release commit
- add regression contracts for the workflow invocation, tag gate, artifact identity check, and concise npm pack diagnostics

## Validation
- `npm run validate:prepush`
- `bash scripts/unity/export-unitypackage.sh --stage-only`
- Unity license check was attempted locally but Unity is not licensed in this environment, so Unity editor tests were left to CI

Root cause confirmed from failing run `28526956444`: `release-prepare.yml` used array splatting in a way that passed `-Bump` as the positional value for the `Bump` parameter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release automation gates (prepare invocation, tag failure mode, pre-publish artifact checks); mistakes could block releases or allow wrong packages if checks are wrong, but scope is CI/scripts only with added tests.
> 
> **Overview**
> **Release prepare** now calls `prepare-release.ps1` with explicit `-Bump` and `-Version` arguments instead of array splatting, fixing a bug where `-Bump` could be bound as the bump value when the workflow passed an empty explicit version.
> 
> **Release publish** strengthens **Verify downloaded artifacts**: it requires non-empty `release-notes.md`, reads `package/package.json` from the npm tarball, and fails if name/version do not match the verified tag outputs—before npm/GitHub publish.
> 
> **Release tag** treats the “CHANGELOG documents this version but head is not a release commit and no local tag” case as a **hard failure** (`::error` + `exit 1`) instead of a warning, surfacing squash-merge title drift.
> 
> **`validate-npm-package.ps1`** validates `package.json` version up front, runs `npm pack --json` with stdout/stderr redirected, and logs a short pack summary instead of dumping full pack output.
> 
> Regression contracts in `test-release-tools.ps1` and `test-sync-script-contracts.ps1` lock in the workflow invocation, tag gate, artifact identity checks, and concise pack diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559acb977d3371b28058d01d755037a6846f3fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->