### PR TITLE
[codex] Stabilize Tags timing tests

### DIFF
--- a/.llm/skills/linter-reference.md
+++ b/.llm/skills/linter-reference.md
@@ -266,22 +266,6 @@ npm run lint:csharp-naming
 | Parameters        | camelCase                | `itemCount`     |
 | Type parameters   | `T` or `T` + PascalCase  | `T`, `TValue`   |
 
-### Common Violations
-
-```csharp
-// ❌ WRONG: lowercase method name
-public void processData() { }
-
-// ✅ CORRECT: PascalCase method name
-public void ProcessData() { }
-
-// ❌ WRONG: missing underscore prefix
-private int count;
-
-// ✅ CORRECT: underscore prefix
-private int _count;
-```
-
 ---
 
 ## YAML Linter
@@ -335,6 +319,9 @@ pwsh -NoProfile -File scripts/lint-tests.ps1
    `results.xml` that aborts the whole leg. Use `yield return null` (the production helper is
    batchmode-safe). A bare reference without `yield return` is not flagged. Add `// UNH-SUPPRESS`
    to opt out.
+9. **UNH013**: Non-performance `Tests/Runtime/Tags` tests must not construct
+   `WaitForSeconds` or `WaitForSecondsRealtime`; use deterministic `EffectHandler` clock/tick seams.
+   Add `// UNH-SUPPRESS UNH013` only for tests that intentionally verify real Unity lifecycle timing.
 
 All Unity object creation in tests must use `Track()`:
 
@@ -393,7 +380,8 @@ Every file and directory under scanned source roots (`Runtime`, `Editor`, `Tests
 
 ### Exclusion Configuration
 
-The script excludes certain paths from requiring `.meta` files. Exclusions are defined in three arrays at the top of [lint-meta-files.ps1](../../scripts/lint-meta-files.ps1):
+The script excludes certain paths from requiring `.meta` files. Exclusions are defined in three arrays at
+the top of [lint-meta-files.ps1](../../scripts/lint-meta-files.ps1):
 
 | Array                  | Purpose                                          | Examples                                                      |
 | ---------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
@@ -405,19 +393,23 @@ The script excludes certain paths from requiring `.meta` files. Exclusions are d
 
 When introducing new tooling that creates cache or artifact directories inside source roots:
 
-1. Add the directory name to `$excludeDirs` (for directories) or file pattern to `$excludeFilePatterns` (for files)
+1. Add the directory name to `$excludeDirs` (for directories) or file pattern to `$excludeFilePatterns`
+   (for files)
 2. Add test cases to [test-lint-meta-exclusions.sh](../../scripts/tests/test-lint-meta-exclusions.sh)
 3. Run the tests: `bash scripts/tests/test-lint-meta-exclusions.sh`
 
 ### Test-ShouldExclude Function
 
-The `Test-ShouldExclude` function checks whether a path should be excluded. For `$excludeDirs` entries, it matches:
+The `Test-ShouldExclude` function checks whether a path should be excluded. For `$excludeDirs` entries,
+it matches:
 
 - The directory itself: `$relativePath -eq $dir` or `$relativePath -like "*/$dir"`
 - Contents at root level: `$relativePath -like "$dir/*"`
 - Nested contents: `$relativePath -like "*/$dir/*"`
 
-Patterns must match **both** the excluded directory itself **and** its contents. If only contents are matched (e.g., `$dir/*` without `$dir`), orphaned `.meta` files for the directory itself won't be detected correctly.
+Patterns must match **both** the excluded directory itself **and** its contents. If only contents are
+matched (e.g., `$dir/*` without `$dir`), orphaned `.meta` files for the directory itself won't be
+detected correctly.
 
 ### Tests
 

--- a/.llm/skills/test-unity-lifecycle.md
+++ b/.llm/skills/test-unity-lifecycle.md
@@ -32,6 +32,7 @@ For Odin-specific testing, see [test-odin-drawers](./test-odin-drawers.md).
 | `UNH002` | Unity object allocation must be tracked: wrap with `Track()`                                        |
 | `UNH003` | Test class creates Unity objects but doesn't inherit from `CommonTestBase`                          |
 | `UNH005` | Unity null checks must use `Assert.IsTrue(x != null/ == null)` instead of `Assert.IsNotNull/IsNull` |
+| `UNH013` | Runtime Tags tests must not use `WaitForSeconds`/`WaitForSecondsRealtime` for handler time math     |
 
 ---
 
@@ -320,6 +321,29 @@ going through one of these (or an equivalent bounded poll). Both helpers
 `PauseBatch()` first, so they also work inside a fixture-wide `BatchedEditorTestBase`
 batch. They use no `WaitForSeconds`/`Thread.Sleep` (editor refreshes are
 synchronous), so they do not trip UNH010.
+
+---
+
+## Runtime Tags timing tests use handler clock seams
+
+`Tests/Runtime/Tags` tests must not assert `EffectHandler` duration, periodic, or behavior-tick
+semantics through literal `WaitForSeconds`/`WaitForSecondsRealtime` waits. Unity does not promise
+exact resume timing for those waits, and standalone IL2CPP legs can resume late enough to observe a
+different tick or remaining-duration value.
+
+Use the handler's internal deterministic seams for effect-system time math:
+
+- `ApplyEffectForTesting(effect, currentTime)` seeds duration expiration and periodic runtime start time.
+- `TryGetRemainingDuration(handle, currentTime, out remaining)` verifies remaining-duration math.
+- `EnsureHandle(effect, refreshDuration, currentTime)` and
+  `RefreshEffect(handle, ignoreReapplicationPolicy, currentTime)` verify refresh policy.
+- `ProcessBehaviorTicksForTesting(deltaTime)` and
+  `ProcessPeriodicEffectsForTesting(currentTime, deltaTime)` verify callback and periodic tick behavior.
+
+`yield return null` is still valid when the test is observing real Unity lifecycle behavior such as
+component initialization or deferred object destruction. If a Tags test genuinely must use a real wait
+for Unity lifecycle timing, keep the wait local to that assertion and add `// UNH-SUPPRESS UNH013`
+with the reason.
 
 ---
 

--- a/Runtime/Tags/EffectHandler.cs
+++ b/Runtime/Tags/EffectHandler.cs
@@ -140,6 +140,16 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// </remarks>
         public EffectHandle? ApplyEffect(AttributeEffect effect)
         {
+            return ApplyEffect(effect, Time.time);
+        }
+
+        internal EffectHandle? ApplyEffectForTesting(AttributeEffect effect, float currentTime)
+        {
+            return ApplyEffect(effect, currentTime);
+        }
+
+        private EffectHandle? ApplyEffect(AttributeEffect effect, float currentTime)
+        {
             if (effect == null)
             {
                 return null;
@@ -177,7 +187,7 @@ namespace WallstopStudios.UnityHelpers.Tags
                     if (existingHandles is { Count: > 0 })
                     {
                         EffectHandle handle = existingHandles[0];
-                        InternalApplyEffect(handle);
+                        InternalApplyEffect(handle, currentTime);
                         return handle;
                     }
 
@@ -215,7 +225,7 @@ namespace WallstopStudios.UnityHelpers.Tags
 
             EffectHandle newHandle = EffectHandle.CreateInstance(effect);
             RegisterStackHandle(stackKey, newHandle);
-            InternalApplyEffect(newHandle);
+            InternalApplyEffect(newHandle, currentTime);
             return newHandle;
         }
 
@@ -473,6 +483,15 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// <returns><c>true</c> if the handle has a tracked duration; otherwise, <c>false</c>.</returns>
         public bool TryGetRemainingDuration(EffectHandle handle, out float remainingDuration)
         {
+            return TryGetRemainingDuration(handle, Time.time, out remainingDuration);
+        }
+
+        internal bool TryGetRemainingDuration(
+            EffectHandle handle,
+            float currentTime,
+            out float remainingDuration
+        )
+        {
             long handleId = handle.id;
             if (!_effectExpirations.TryGetValue(handleId, out float expiration))
             {
@@ -480,7 +499,7 @@ namespace WallstopStudios.UnityHelpers.Tags
                 return false;
             }
 
-            float timeRemaining = expiration - Time.time;
+            float timeRemaining = expiration - currentTime;
             if (timeRemaining < 0f)
             {
                 timeRemaining = 0f;
@@ -510,6 +529,15 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// <returns>An active handle for the effect, or <c>null</c> for instant effects.</returns>
         public EffectHandle? EnsureHandle(AttributeEffect effect, bool refreshDuration)
         {
+            return EnsureHandle(effect, refreshDuration, Time.time);
+        }
+
+        internal EffectHandle? EnsureHandle(
+            AttributeEffect effect,
+            bool refreshDuration,
+            float currentTime
+        )
+        {
             if (effect == null)
             {
                 return null;
@@ -521,14 +549,14 @@ namespace WallstopStudios.UnityHelpers.Tags
                 {
                     if (refreshDuration)
                     {
-                        _ = RefreshEffect(handle);
+                        _ = RefreshEffect(handle, ignoreReapplicationPolicy: false, currentTime);
                     }
 
                     return handle;
                 }
             }
 
-            return ApplyEffect(effect);
+            return ApplyEffect(effect, currentTime);
         }
 
         /// <summary>
@@ -550,6 +578,15 @@ namespace WallstopStudios.UnityHelpers.Tags
         /// </param>
         /// <returns><c>true</c> if the duration was refreshed; otherwise, <c>false</c>.</returns>
         public bool RefreshEffect(EffectHandle handle, bool ignoreReapplicationPolicy)
+        {
+            return RefreshEffect(handle, ignoreReapplicationPolicy, Time.time);
+        }
+
+        internal bool RefreshEffect(
+            EffectHandle handle,
+            bool ignoreReapplicationPolicy,
+            float currentTime
+        )
         {
             AttributeEffect effect = handle.effect;
             if (effect == null)
@@ -573,7 +610,7 @@ namespace WallstopStudios.UnityHelpers.Tags
                 return false;
             }
 
-            float newExpiration = Time.time + effect.duration;
+            float newExpiration = currentTime + effect.duration;
             _effectExpirations[handleId] = newExpiration;
             _effectHandlesById[handleId] = handle;
             return true;
@@ -607,7 +644,7 @@ namespace WallstopStudios.UnityHelpers.Tags
             OnEffectRemoved?.Invoke(handle);
         }
 
-        private void InternalApplyEffect(EffectHandle handle)
+        private void InternalApplyEffect(EffectHandle handle, float currentTime)
         {
             bool exists = _appliedEffects.Contains(handle);
             if (!exists)
@@ -623,13 +660,13 @@ namespace WallstopStudios.UnityHelpers.Tags
             {
                 if (!exists || effect.resetDurationOnReapplication)
                 {
-                    _effectExpirations[handleId] = Time.time + effect.duration;
+                    _effectExpirations[handleId] = currentTime + effect.duration;
                 }
             }
 
             if (!exists)
             {
-                RegisterPeriodicRuntime(handle);
+                RegisterPeriodicRuntime(handle, currentTime);
                 RegisterBehaviors(handle);
             }
 
@@ -692,7 +729,7 @@ namespace WallstopStudios.UnityHelpers.Tags
             }
         }
 
-        private void RegisterPeriodicRuntime(EffectHandle handle)
+        private void RegisterPeriodicRuntime(EffectHandle handle, float startTime)
         {
             AttributeEffect effect = handle.effect;
             if (effect.periodicEffects is not { Count: > 0 })
@@ -702,7 +739,6 @@ namespace WallstopStudios.UnityHelpers.Tags
 
             List<PeriodicEffectRuntimeState> runtimeStates = null;
             PooledResource<List<PeriodicEffectRuntimeState>> runtimeStatesLease = default;
-            float startTime = Time.time;
 
             foreach (PeriodicEffectDefinition definition in effect.periodicEffects)
             {
@@ -1101,16 +1137,26 @@ namespace WallstopStudios.UnityHelpers.Tags
 
         private void ProcessBehaviorTicks()
         {
+            _ = ProcessBehaviorTicks(Time.deltaTime);
+        }
+
+        internal int ProcessBehaviorTicksForTesting(float deltaTime)
+        {
+            return ProcessBehaviorTicks(deltaTime);
+        }
+
+        private int ProcessBehaviorTicks(float deltaTime)
+        {
             if (_behaviorsByHandleId.Count <= 0)
             {
-                return;
+                return 0;
             }
 
             using PooledResource<List<long>> behaviorHandleIdsResource = Buffers<long>.List.Get(
                 out List<long> behaviorHandleIdsBuffer
             );
             behaviorHandleIdsBuffer.AddRange(_behaviorsByHandleId.Keys);
-            float deltaTime = Time.deltaTime;
+            int processedTicks = 0;
 
             foreach (long handleId in behaviorHandleIdsBuffer)
             {
@@ -1139,8 +1185,11 @@ namespace WallstopStudios.UnityHelpers.Tags
                     }
 
                     behavior.OnTick(context);
+                    ++processedTicks;
                 }
             }
+
+            return processedTicks;
         }
 
         private void ProcessPeriodicEffects()

--- a/Runtime/Tags/EffectHandler.cs
+++ b/Runtime/Tags/EffectHandler.cs
@@ -549,7 +549,11 @@ namespace WallstopStudios.UnityHelpers.Tags
                 {
                     if (refreshDuration)
                     {
-                        _ = RefreshEffect(handle, ignoreReapplicationPolicy: false, currentTime);
+                        _ = RefreshEffect(
+                            handle,
+                            ignoreReapplicationPolicy: false,
+                            currentTime: currentTime
+                        );
                     }
 
                     return handle;

--- a/Tests/Runtime/Tags/AttributeUtilitiesTests.cs
+++ b/Tests/Runtime/Tags/AttributeUtilitiesTests.cs
@@ -536,22 +536,23 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float remaining));
             Assert.Greater(remaining, 0f);
 
-            yield return null;
-            Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float beforeEnsure));
+            EffectHandler handler = entity.GetComponent<EffectHandler>();
+            handler.RemoveEffect(activeHandle);
+            activeHandle = handler.ApplyEffectForTesting(effect, currentTime: -10f).Value;
+            Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float beforeNoRefresh));
+            Assert.AreEqual(0f, beforeNoRefresh);
+
+            EffectHandle? ensuredNoRefresh = entity.EnsureHandle(effect, refreshDuration: false);
+            Assert.IsTrue(ensuredNoRefresh.HasValue);
+            Assert.AreEqual(activeHandle, ensuredNoRefresh.Value);
+            Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float afterNoRefresh));
+            Assert.AreEqual(0f, afterNoRefresh);
 
             EffectHandle? ensured = entity.EnsureHandle(effect);
             Assert.IsTrue(ensured.HasValue);
             Assert.AreEqual(activeHandle, ensured.Value);
             Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float afterEnsure));
-            Assert.Greater(afterEnsure, beforeEnsure);
-
-            yield return null;
-            Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float beforeNoRefresh));
-            EffectHandle? ensuredNoRefresh = entity.EnsureHandle(effect, refreshDuration: false);
-            Assert.IsTrue(ensuredNoRefresh.HasValue);
-            Assert.AreEqual(activeHandle, ensuredNoRefresh.Value);
-            Assert.IsTrue(entity.TryGetRemainingDuration(activeHandle, out float afterNoRefresh));
-            Assert.LessOrEqual(afterNoRefresh, beforeNoRefresh);
+            Assert.Greater(afterEnsure, afterNoRefresh);
 
             Assert.IsTrue(entity.RefreshEffect(activeHandle));
 
@@ -613,10 +614,15 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = entity.ApplyEffect(effect).Value;
-            yield return null;
+            EffectHandler handler = entity.GetComponent<EffectHandler>();
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: -10f).Value;
+            Assert.IsTrue(entity.TryGetRemainingDuration(handle, out float beforeRefresh));
+            Assert.AreEqual(0f, beforeRefresh);
+
             Assert.IsFalse(entity.RefreshEffect(handle));
             Assert.IsTrue(entity.RefreshEffect(handle, ignoreReapplicationPolicy: true));
+            Assert.IsTrue(entity.TryGetRemainingDuration(handle, out float afterRefresh));
+            Assert.Greater(afterRefresh, beforeRefresh);
         }
 
         [UnityTest]

--- a/Tests/Runtime/Tags/EffectBehaviorTests.cs
+++ b/Tests/Runtime/Tags/EffectBehaviorTests.cs
@@ -21,8 +21,8 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             RecordingEffectBehavior.ResetForTests();
         }
 
-        [UnityTest]
-        public IEnumerator LifecycleCallbacksProvideContextData()
+        [Test]
+        public void LifecycleCallbacksProvideContextData()
         {
             (GameObject entity, EffectHandler handler, _, _) = CreateEntity();
 
@@ -47,7 +47,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             );
             effect.behaviors.Add(behavior);
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 10f).Value;
             Assert.AreEqual(1, RecordingEffectBehavior.ApplyCount);
             Assert.AreEqual(
                 1,
@@ -55,19 +55,18 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 "OnApply should fire immediately."
             );
 
-            yield return null;
-            yield return null;
-
+            int tickCount = handler.ProcessBehaviorTicksForTesting(deltaTime: 0.02f);
+            Assert.AreEqual(1, tickCount);
             Assert.IsNotEmpty(
                 RecordingEffectBehavior.TickContexts,
-                "OnTick should run after Update."
+                "OnTick should run when behavior ticks are processed."
             );
 
-            yield return WaitForPeriodicInvocations(
-                expectedCount: 1,
-                timeout: 0.5f,
-                checkpoint: "lifecycle periodic tick"
+            int periodicTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 10f,
+                deltaTime: 0.02f
             );
+            Assert.AreEqual(1, periodicTicks);
 
             Assert.AreEqual(
                 1,
@@ -94,17 +93,17 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.AreSame(handler, tickContext.handler);
             Assert.AreSame(entity, tickContext.Target);
             Assert.AreEqual(effect, tickContext.Effect);
-            Assert.Greater(tickContext.deltaTime, 0f);
+            Assert.AreEqual(0.02f, tickContext.deltaTime);
 
             RecordingEffectBehavior.PeriodicInvocation periodicInvocation =
                 RecordingEffectBehavior.PeriodicInvocations[0];
             Assert.AreSame(handler, periodicInvocation.Context.handler);
             Assert.AreSame(entity, periodicInvocation.Context.Target);
             Assert.AreEqual(effect, periodicInvocation.Context.Effect);
-            Assert.Greater(periodicInvocation.Context.deltaTime, 0f);
+            Assert.AreEqual(0.02f, periodicInvocation.Context.deltaTime);
             Assert.AreSame(periodicDefinition, periodicInvocation.TickContext.definition);
             Assert.AreEqual(1, periodicInvocation.TickContext.executedTicks);
-            Assert.GreaterOrEqual(periodicInvocation.TickContext.currentTime, 0f);
+            Assert.AreEqual(10f, periodicInvocation.TickContext.currentTime);
 
             EffectBehaviorContext removeContext = RecordingEffectBehavior.RemoveContexts[0];
             Assert.AreSame(handler, removeContext.handler);
@@ -113,8 +112,8 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.AreEqual(0f, removeContext.deltaTime);
         }
 
-        [UnityTest]
-        public IEnumerator PeriodicTickContextTracksExecutedTicksAndTime()
+        [Test]
+        public void PeriodicTickContextTracksExecutedTicksAndTime()
         {
             (GameObject entity, EffectHandler handler, _, _) = CreateEntity();
 
@@ -139,13 +138,13 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             );
             effect.behaviors.Add(behavior);
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 20f).Value;
 
-            yield return WaitForPeriodicInvocations(
-                expectedCount: 3,
-                timeout: 0.75f,
-                checkpoint: "three periodic behavior callbacks"
+            int ticks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 20.11f,
+                deltaTime: 0.11f
             );
+            Assert.AreEqual(3, ticks);
 
             Assert.AreEqual(
                 3,
@@ -159,7 +158,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                     RecordingEffectBehavior.PeriodicInvocations[i];
                 Assert.AreSame(periodicDefinition, invocation.TickContext.definition);
                 Assert.AreEqual(i + 1, invocation.TickContext.executedTicks);
-                Assert.Greater(invocation.Context.deltaTime, 0f);
+                Assert.AreEqual(0.11f, invocation.Context.deltaTime);
 
                 if (i > 0)
                 {
@@ -174,27 +173,50 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             handler.RemoveEffect(handle);
         }
 
-        private static IEnumerator WaitForPeriodicInvocations(
-            int expectedCount,
-            float timeout,
-            string checkpoint
-        )
+        [UnityTest]
+        public IEnumerator UpdateProcessesBehaviorAndPeriodicTicks()
         {
-            float elapsed = 0f;
-            while (
-                RecordingEffectBehavior.PeriodicInvocations.Count < expectedCount
-                && elapsed < timeout
-            )
-            {
-                yield return null;
-                elapsed += Time.deltaTime;
-            }
+            (_, EffectHandler handler, _, _) = CreateEntity();
 
-            Assert.That(
-                RecordingEffectBehavior.PeriodicInvocations.Count,
-                Is.GreaterThanOrEqualTo(expectedCount),
-                $"{checkpoint} not reached within {timeout:F2}s (saw {RecordingEffectBehavior.PeriodicInvocations.Count})."
+            PeriodicEffectDefinition periodicDefinition = new()
+            {
+                name = "Update Pulse",
+                initialDelay = 0f,
+                interval = 0.05f,
+                maxTicks = 1,
+            };
+
+            AttributeEffect effect = CreateEffect(
+                "Update Lifecycle",
+                e =>
+                {
+                    e.periodicEffects.Add(periodicDefinition);
+                }
             );
+
+            RecordingEffectBehavior behavior = Track(
+                ScriptableObject.CreateInstance<RecordingEffectBehavior>()
+            );
+            effect.behaviors.Add(behavior);
+
+            EffectHandle handle = handler.ApplyEffect(effect).Value;
+            Assert.AreEqual(0, RecordingEffectBehavior.TickCount);
+            Assert.AreEqual(0, RecordingEffectBehavior.PeriodicTickCount);
+
+            yield return null;
+
+            Assert.Greater(
+                RecordingEffectBehavior.TickCount,
+                0,
+                "Update should process behavior ticks without a direct test seam call."
+            );
+            Assert.AreEqual(
+                1,
+                RecordingEffectBehavior.PeriodicTickCount,
+                "Update should process the zero-delay periodic tick without a real-time wait."
+            );
+
+            handler.RemoveEffect(handle);
         }
 
         private (

--- a/Tests/Runtime/Tags/EffectHandlerTests.cs
+++ b/Tests/Runtime/Tags/EffectHandlerTests.cs
@@ -538,8 +538,8 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.AreEqual(100f, attributes.health.CurrentValue, 0.01f);
 
             int beforeDelayTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 5.03f,
-                deltaTime: 0.03f
+                currentTime: 5.049f,
+                deltaTime: 0.049f
             );
             Assert.AreEqual(0, beforeDelayTicks);
             Assert.Zero(
@@ -548,21 +548,21 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             );
 
             int firstTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 5.05f,
+                currentTime: 5.051f,
                 deltaTime: 0.05f
             );
             Assert.AreEqual(1, firstTicks);
             Assert.AreEqual(90f, attributes.health.CurrentValue, 0.01f);
 
             int secondTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 5.1f,
+                currentTime: 5.101f,
                 deltaTime: 0.05f
             );
             Assert.AreEqual(1, secondTicks);
             Assert.AreEqual(80f, attributes.health.CurrentValue, 0.01f);
 
             int afterMaxTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 5.2f,
+                currentTime: 5.201f,
                 deltaTime: 0.1f
             );
             Assert.AreEqual(0, afterMaxTicks);
@@ -721,19 +721,19 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 50f).Value;
 
             int firstTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 50.02f,
+                currentTime: 50.021f,
                 deltaTime: 0.02f
             );
             Assert.AreEqual(1, firstTicks);
 
             int secondTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 50.05f,
+                currentTime: 50.051f,
                 deltaTime: 0.03f
             );
             Assert.AreEqual(1, secondTicks);
 
             int finalTicks = handler.ProcessPeriodicEffectsForTesting(
-                currentTime: 50.22f,
+                currentTime: 50.221f,
                 deltaTime: 0.17f
             );
             Assert.AreEqual(3, finalTicks);

--- a/Tests/Runtime/Tags/EffectHandlerTests.cs
+++ b/Tests/Runtime/Tags/EffectHandlerTests.cs
@@ -360,16 +360,25 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return new WaitForSeconds(0.05f);
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float beforeReapply));
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 10f).Value;
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 10.05f,
+                    out float beforeReapply
+                )
+            );
+            Assert.AreEqual(0.25f, beforeReapply, RemainingDurationEpsilon);
 
-            EffectHandle? reapplied = handler.ApplyEffect(effect);
+            EffectHandle? reapplied = handler.ApplyEffectForTesting(effect, currentTime: 10.2f);
             Assert.IsTrue(reapplied.HasValue);
             Assert.AreEqual(handle, reapplied.Value);
 
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float afterReapply));
-            Assert.LessOrEqual(afterReapply, beforeReapply + 0.01f);
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(handle, currentTime: 10.2f, out float afterReapply)
+            );
+            Assert.AreEqual(0.1f, afterReapply, RemainingDurationEpsilon);
+            Assert.Less(afterReapply, beforeReapply);
 
             handler.RemoveEffect(handle);
         }
@@ -521,82 +530,42 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return null;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 5f).Value;
             Assert.AreEqual(100f, attributes.health.CurrentValue, 0.01f);
 
-            yield return new WaitForSeconds(0.03f);
+            int beforeDelayTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 5.03f,
+                deltaTime: 0.03f
+            );
+            Assert.AreEqual(0, beforeDelayTicks);
             Assert.Zero(
                 attributes.notifications.Count,
                 "No periodic ticks should occur before the initial delay elapses."
             );
 
-            yield return WaitForAttributeNotifications(
-                attributes,
-                expectedCount: 1,
-                timeout: 0.5f,
-                checkpoint: "first periodic tick"
+            int firstTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 5.05f,
+                deltaTime: 0.05f
             );
+            Assert.AreEqual(1, firstTicks);
             Assert.AreEqual(90f, attributes.health.CurrentValue, 0.01f);
 
-            yield return WaitForAttributeNotifications(
-                attributes,
-                expectedCount: 2,
-                timeout: 0.5f,
-                checkpoint: "second periodic tick"
+            int secondTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 5.1f,
+                deltaTime: 0.05f
             );
+            Assert.AreEqual(1, secondTicks);
             Assert.AreEqual(80f, attributes.health.CurrentValue, 0.01f);
 
-            yield return AssertNoAdditionalAttributeNotifications(
-                attributes,
-                expectedCount: 2,
-                holdDuration: 0.2f,
-                checkpoint: "max tick enforcement"
+            int afterMaxTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 5.2f,
+                deltaTime: 0.1f
             );
+            Assert.AreEqual(0, afterMaxTicks);
+            Assert.AreEqual(2, attributes.notifications.Count);
             Assert.AreEqual(80f, attributes.health.CurrentValue, 0.01f);
 
             handler.RemoveEffect(handle);
-        }
-
-        private static IEnumerator WaitForAttributeNotifications(
-            TestAttributesComponent attributes,
-            int expectedCount,
-            float timeout,
-            string checkpoint
-        )
-        {
-            float elapsed = 0f;
-            while (attributes.notifications.Count < expectedCount && elapsed < timeout)
-            {
-                yield return null;
-                elapsed += Time.deltaTime;
-            }
-
-            Assert.That(
-                attributes.notifications.Count,
-                Is.GreaterThanOrEqualTo(expectedCount),
-                $"{checkpoint} not reached within {timeout:F2}s (saw {attributes.notifications.Count})."
-            );
-        }
-
-        private static IEnumerator AssertNoAdditionalAttributeNotifications(
-            TestAttributesComponent attributes,
-            int expectedCount,
-            float holdDuration,
-            string checkpoint
-        )
-        {
-            float elapsed = 0f;
-            while (elapsed < holdDuration)
-            {
-                Assert.AreEqual(
-                    expectedCount,
-                    attributes.notifications.Count,
-                    $"{checkpoint}: detected unexpected periodic ticks after reaching the expected count."
-                );
-                yield return null;
-                elapsed += Time.deltaTime;
-            }
         }
 
         [UnityTest]
@@ -628,14 +597,22 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return new WaitForSeconds(0.16f);
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 20f).Value;
+            int ticks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 20.16f,
+                deltaTime: 0.16f
+            );
+            Assert.Greater(ticks, 0);
             float afterTicks = attributes.health.CurrentValue;
             Assert.Less(afterTicks, 100f);
 
             handler.RemoveEffect(handle);
             float afterRemoval = attributes.health.CurrentValue;
-            yield return new WaitForSeconds(0.1f);
+            int ticksAfterRemoval = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 20.26f,
+                deltaTime: 0.1f
+            );
+            Assert.AreEqual(0, ticksAfterRemoval);
             Assert.AreEqual(afterRemoval, attributes.health.CurrentValue, 0.01f);
         }
 
@@ -662,8 +639,8 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            float overdueTime = Time.time + 10f;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 30f).Value;
+            float overdueTime = 40f;
 
             int firstCatchUpTicks = handler.ProcessPeriodicEffectsForTesting(
                 overdueTime,
@@ -737,14 +714,26 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 50f).Value;
 
-            yield return WaitForAttributeNotifications(
-                attributes,
-                expectedCount: 5,
-                timeout: 0.75f,
-                checkpoint: "all independent periodic ticks"
+            int firstTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 50.02f,
+                deltaTime: 0.02f
             );
+            Assert.AreEqual(1, firstTicks);
+
+            int secondTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 50.05f,
+                deltaTime: 0.03f
+            );
+            Assert.AreEqual(1, secondTicks);
+
+            int finalTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 50.22f,
+                deltaTime: 0.17f
+            );
+            Assert.AreEqual(3, finalTicks);
+            Assert.AreEqual(5, attributes.notifications.Count);
 
             int healthTicks = 0;
             int armorTicks = 0;
@@ -787,8 +776,10 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float remaining));
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 70f).Value;
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(handle, currentTime: 70f, out float remaining)
+            );
             Assert.Greater(remaining, 0f);
             Assert.LessOrEqual(
                 remaining,
@@ -821,25 +812,57 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float initialRemaining));
-            yield return null;
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float beforeRefresh));
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 100f).Value;
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 100f,
+                    out float initialRemaining
+                )
+            );
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 100.05f,
+                    out float beforeRefresh
+                )
+            );
             Assert.Less(beforeRefresh, initialRemaining);
 
-            EffectHandle? ensured = handler.EnsureHandle(effect);
+            EffectHandle? ensured = handler.EnsureHandle(
+                effect,
+                refreshDuration: true,
+                currentTime: 100.1f
+            );
             Assert.IsTrue(ensured.HasValue);
             Assert.AreEqual(handle, ensured.Value);
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float afterRefresh));
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(handle, currentTime: 100.1f, out float afterRefresh)
+            );
             Assert.Greater(afterRefresh, beforeRefresh);
 
-            yield return null;
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float beforeNoRefresh));
-            EffectHandle? ensuredNoRefresh = handler.EnsureHandle(effect, refreshDuration: false);
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 100.15f,
+                    out float beforeNoRefresh
+                )
+            );
+            EffectHandle? ensuredNoRefresh = handler.EnsureHandle(
+                effect,
+                refreshDuration: false,
+                currentTime: 100.18f
+            );
             Assert.IsTrue(ensuredNoRefresh.HasValue);
             Assert.AreEqual(handle, ensuredNoRefresh.Value);
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float afterNoRefresh));
-            Assert.LessOrEqual(afterNoRefresh, beforeNoRefresh);
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 100.18f,
+                    out float afterNoRefresh
+                )
+            );
+            Assert.Less(afterNoRefresh, beforeNoRefresh);
 
             handler.RemoveEffect(handle);
         }
@@ -864,13 +887,26 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return null;
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float beforeRefresh));
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 200f).Value;
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 200.1f,
+                    out float beforeRefresh
+                )
+            );
 
             Assert.IsFalse(handler.RefreshEffect(handle));
-            Assert.IsTrue(handler.RefreshEffect(handle, ignoreReapplicationPolicy: true));
-            Assert.IsTrue(handler.TryGetRemainingDuration(handle, out float afterRefresh));
+            Assert.IsTrue(
+                handler.RefreshEffect(handle, ignoreReapplicationPolicy: true, currentTime: 200.15f)
+            );
+            Assert.IsTrue(
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 200.15f,
+                    out float afterRefresh
+                )
+            );
             Assert.Greater(afterRefresh, beforeRefresh);
 
             handler.RemoveEffect(handle);
@@ -905,11 +941,19 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 }
             );
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return new WaitForSeconds(0.35f);
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 300f).Value;
+            int ticks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 300.35f,
+                deltaTime: 0.35f
+            );
+            Assert.AreEqual(3, ticks);
             Assert.AreEqual(70f, attributes.health.CurrentValue, 0.01f);
 
-            yield return new WaitForSeconds(0.2f);
+            int afterMaxTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 300.55f,
+                deltaTime: 0.2f
+            );
+            Assert.AreEqual(0, afterMaxTicks);
             handler.RemoveEffect(handle);
             Assert.AreEqual(70f, attributes.health.CurrentValue, 0.01f);
         }
@@ -941,14 +985,24 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             );
             effect.behaviors.Add(behavior);
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 400f).Value;
             Assert.AreEqual(1, RecordingEffectBehavior.ApplyCount);
 
-            yield return null;
+            int tickCount = handler.ProcessBehaviorTicksForTesting(deltaTime: 0.033f);
+            Assert.AreEqual(1, tickCount);
             Assert.Greater(RecordingEffectBehavior.TickCount, 0);
+            Assert.AreEqual(0.033f, RecordingEffectBehavior.TickContexts[0].deltaTime);
 
-            yield return new WaitForSeconds(0.12f);
+            int periodicTicks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 400.12f,
+                deltaTime: 0.12f
+            );
+            Assert.AreEqual(2, periodicTicks);
             Assert.GreaterOrEqual(RecordingEffectBehavior.PeriodicTickCount, 1);
+            Assert.AreEqual(
+                0.12f,
+                RecordingEffectBehavior.PeriodicInvocations[0].Context.deltaTime
+            );
 
             handler.RemoveEffect(handle);
             Assert.AreEqual(1, RecordingEffectBehavior.RemoveCount);
@@ -1017,8 +1071,9 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             );
             effect.behaviors.Add(behavior);
 
-            EffectHandle handle = handler.ApplyEffect(effect).Value;
-            yield return new WaitForSeconds(0.1f);
+            EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 500f).Value;
+            int tickCount = handler.ProcessBehaviorTicksForTesting(deltaTime: 0.1f);
+            Assert.AreEqual(1, tickCount);
 
             Assert.AreEqual(0, RecordingEffectBehavior.PeriodicTickCount);
 
@@ -1097,7 +1152,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             EffectHandle? handle = handler.ApplyEffect(effect);
             Assert.IsFalse(handle.HasValue);
 
-            yield return new WaitForSeconds(0.1f);
+            int ticks = handler.ProcessPeriodicEffectsForTesting(
+                currentTime: 600f,
+                deltaTime: 0.1f
+            );
+            Assert.AreEqual(0, ticks);
             Assert.AreEqual(100f, attributes.health.CurrentValue, 0.01f);
         }
 

--- a/Tests/Runtime/Tags/EffectHandlerTests.cs
+++ b/Tests/Runtime/Tags/EffectHandlerTests.cs
@@ -365,7 +365,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 10.05f,
-                    out float beforeReapply
+                    remainingDuration: out float beforeReapply
                 )
             );
             Assert.AreEqual(0.25f, beforeReapply, RemainingDurationEpsilon);
@@ -375,7 +375,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.AreEqual(handle, reapplied.Value);
 
             Assert.IsTrue(
-                handler.TryGetRemainingDuration(handle, currentTime: 10.2f, out float afterReapply)
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 10.2f,
+                    remainingDuration: out float afterReapply
+                )
             );
             Assert.AreEqual(0.1f, afterReapply, RemainingDurationEpsilon);
             Assert.Less(afterReapply, beforeReapply);
@@ -778,7 +782,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
 
             EffectHandle handle = handler.ApplyEffectForTesting(effect, currentTime: 70f).Value;
             Assert.IsTrue(
-                handler.TryGetRemainingDuration(handle, currentTime: 70f, out float remaining)
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 70f,
+                    remainingDuration: out float remaining
+                )
             );
             Assert.Greater(remaining, 0f);
             Assert.LessOrEqual(
@@ -817,14 +825,14 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 100f,
-                    out float initialRemaining
+                    remainingDuration: out float initialRemaining
                 )
             );
             Assert.IsTrue(
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 100.05f,
-                    out float beforeRefresh
+                    remainingDuration: out float beforeRefresh
                 )
             );
             Assert.Less(beforeRefresh, initialRemaining);
@@ -837,7 +845,11 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
             Assert.IsTrue(ensured.HasValue);
             Assert.AreEqual(handle, ensured.Value);
             Assert.IsTrue(
-                handler.TryGetRemainingDuration(handle, currentTime: 100.1f, out float afterRefresh)
+                handler.TryGetRemainingDuration(
+                    handle,
+                    currentTime: 100.1f,
+                    remainingDuration: out float afterRefresh
+                )
             );
             Assert.Greater(afterRefresh, beforeRefresh);
 
@@ -845,7 +857,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 100.15f,
-                    out float beforeNoRefresh
+                    remainingDuration: out float beforeNoRefresh
                 )
             );
             EffectHandle? ensuredNoRefresh = handler.EnsureHandle(
@@ -859,7 +871,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 100.18f,
-                    out float afterNoRefresh
+                    remainingDuration: out float afterNoRefresh
                 )
             );
             Assert.Less(afterNoRefresh, beforeNoRefresh);
@@ -892,7 +904,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 200.1f,
-                    out float beforeRefresh
+                    remainingDuration: out float beforeRefresh
                 )
             );
 
@@ -904,7 +916,7 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
                 handler.TryGetRemainingDuration(
                     handle,
                     currentTime: 200.15f,
-                    out float afterRefresh
+                    remainingDuration: out float afterRefresh
                 )
             );
             Assert.Greater(afterRefresh, beforeRefresh);

--- a/scripts/lint-tests.ps1
+++ b/scripts/lint-tests.ps1
@@ -211,6 +211,63 @@ function Remove-CsStringLiteralsAndLineComments([string]$text) {
   return $sb.ToString()
 }
 
+function Get-CsCommentMaskedText([string]$text) {
+  if ([string]::IsNullOrEmpty($text)) { return $text }
+
+  $lines = $text -split "`n", -1
+  $maskedLines = Get-CommentMaskedLines -Lines $lines -Language 'csharp'
+  $commentMasked = [string]::Join("`n", $maskedLines)
+  if ($commentMasked.Length -ne $text.Length) {
+    return $text
+  }
+
+  return $commentMasked
+}
+
+function Test-CodeSpecificLineSuppression {
+  Param(
+    [string]$Line,
+    [string]$CommentMaskedLine,
+    [string]$Code
+  )
+
+  $suppressionPattern = [regex]('//\s*UNH-SUPPRESS\s+' + [regex]::Escape($Code) + '\b')
+  foreach ($match in $suppressionPattern.Matches($Line)) {
+    if ($match.Index -ge $CommentMaskedLine.Length) { continue }
+    $length = [Math]::Min($match.Length, $CommentMaskedLine.Length - $match.Index)
+    $maskedSuppression = $CommentMaskedLine.Substring($match.Index, $length)
+    if ($maskedSuppression -match '^\s+$') { return $true }
+  }
+
+  return $false
+}
+
+function Test-CodeSpecificSuppressionInLineRange {
+  Param(
+    [string[]]$Lines,
+    [string[]]$CommentMaskedLines,
+    [int]$StartLine,
+    [int]$EndLine,
+    [string]$Code
+  )
+
+  for ($lineNumber = $StartLine; $lineNumber -le $EndLine; $lineNumber++) {
+    $lineIndex = $lineNumber - 1
+    if ($lineIndex -lt 0 -or $lineIndex -ge $Lines.Count) { continue }
+    if ($lineIndex -ge $CommentMaskedLines.Count) { continue }
+    if (
+      Test-CodeSpecificLineSuppression `
+        -Line $Lines[$lineIndex] `
+        -CommentMaskedLine $CommentMaskedLines[$lineIndex] `
+        -Code $Code
+    ) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
 $destroyPattern = [regex]'\b(?:UnityEngine\.)?Object\.(?:DestroyImmediate|Destroy)\s*\((?<arg>[^)]*)\)'
 $createAssignObjectPattern = [regex]'(?<var>\b\w+)\s*=\s*new\s+(?<type>GameObject|Texture2D|Material|Mesh|Camera)\s*\('
 $createInlineTrackPattern = [regex]'\bTrack\s*\(\s*new\s+(?:GameObject|Texture2D|Material|Mesh|Camera)\s*\('
@@ -254,6 +311,7 @@ $inlineTestAttributePattern = [regex]'^\s*\[\s*(?:global\s*::\s*)?(?:[A-Za-z_][\
 # misses. Operates on a SCRUBBED line so "[Test]" inside a string literal
 # cannot match.
 $inlineTestAttributeAnywherePattern = [regex]'\[\s*(?:global\s*::\s*)?(?:[A-Za-z_][\w\.]*\.)?(?:Test|TestCase|TestCaseSource|UnityTest)(?:Attribute)?(?:\s*\(|\s*\]|\s*,)'
+$testFileAttributePattern = [regex]'\[\s*(?:global\s*::\s*)?(?:(?:[A-Za-z_]\w*)\s*(?:\.|::)\s*)*(?:Test|TestCase|TestCaseSource|TestFixture|UnityTest)(?:Attribute)?(?:\s*\(|\s*\]|\s*,)'
 
 # UNH005: Assert.IsNull/IsNotNull patterns (should use Assert.IsTrue for Unity null checks)
 $assertIsNullPattern = [regex]'Assert\.IsNull\s*\('
@@ -261,6 +319,9 @@ $assertIsNotNullPattern = [regex]'Assert\.IsNotNull\s*\('
 $testCaseDataReturnsNullPattern = [regex]'(?ms)\.Returns\s*\(\s*null\s*\)'
 $unityTestAttributePattern = [regex]'\[\s*(?:global\s*::\s*)?(?:[A-Za-z_][\w\.]*\.)?UnityTest(?:Attribute)?(?:\s*\(|\s*\])'
 $coroutineMethodPattern = [regex]'\bIEnumerator\s+(?<name>\w+)\s*\('
+$tagsWaitInstructionPattern = [regex]'\bnew\s+(?:(?:global\s*::\s*)?UnityEngine\s*(?:\.|::)\s*)?WaitForSeconds(?:Realtime)?\s*\('
+$tagsWaitAliasPattern = [regex]'(?m)^\s*(?:global\s+)?using\s+(?<alias>[A-Za-z_]\w*)\s*=\s*(?:global\s*::\s*)?UnityEngine\s*(?:\.|::)\s*WaitForSeconds(?:Realtime)?\s*;'
+$tagsUnityEngineAliasPattern = [regex]'(?m)^\s*(?:global\s+)?using\s+(?<alias>[A-Za-z_]\w*)\s*=\s*(?:global\s*::\s*)?UnityEngine\s*;'
 
 # Returns true if the relative path matches an allowlisted helper file path.
 function Is-AllowlistedFile([string]$relPath) {
@@ -1032,8 +1093,15 @@ function Get-LineNumberAtIndex {
     return 1
   }
 
-  $prefix = $Text.Substring(0, [Math]::Min($Index, $Text.Length))
-  return (($prefix.ToCharArray() | Where-Object { $_ -eq "`n" }).Count + 1)
+  $lineNumber = 1
+  $limit = [Math]::Min($Index, $Text.Length)
+  for ($i = 0; $i -lt $limit; $i++) {
+    if ($Text[$i] -eq "`n") {
+      $lineNumber++
+    }
+  }
+
+  return $lineNumber
 }
 
 function Get-TestCaseSourceBody {
@@ -1277,6 +1345,11 @@ foreach ($file in $filesToScan) {
   # pipeline conditions, which then fails the `.Count` access under
   # StrictMode. Build the array imperatively and re-wrap to guarantee
   # array semantics for downstream `.Count` / indexing access.
+  $commentMaskedText = Get-CsCommentMaskedText $text
+  $commentMaskedContent = @($commentMaskedText -split "`n")
+  $commentMaskedContent = @($commentMaskedContent)
+  if ($commentMaskedContent.Count -ne $content.Count) { $commentMaskedContent = $content }
+
   $scrubbedText = Remove-CsStringLiteralsAndLineComments $text
   if ($null -eq $scrubbedText) {
     $scrubbedContent = $content
@@ -1631,7 +1704,8 @@ foreach ($file in $filesToScan) {
   # folder or is named *PerformanceTests / *BenchmarkTests) MUST carry the
   # Performance or Stress category, otherwise the fast matrix would run it.
   $looksPerf = ($rel -match '(^|/)Performance/') -or [regex]::IsMatch($scrubbedText, '\bclass\s+\w*(Performance|Benchmark)\w*Tests\b')
-  $isTestFile = [regex]::IsMatch($scrubbedText, '\[\s*Test\b|\[\s*TestFixture\b|\[\s*UnityTest\b')
+  $isTestFile = $testFileAttributePattern.IsMatch($scrubbedText)
+  $isRuntimeTagsTest = ($rel -match '^Tests/Runtime/Tags/')
   if ($looksPerf -and $isTestFile -and -not $perfCategory -and ($text -notmatch 'UNH-SUPPRESS.*UNH008')) {
     $violations += (@{
       Path=$rel; Line=1; Message='UNH008: Performance/benchmark fixture must declare [Category("Performance")] or [Category("Stress")] so the main CI matrix (which runs !Performance;!Stress) excludes it'
@@ -1683,8 +1757,55 @@ foreach ($file in $filesToScan) {
       $scrubbedLine = $scrubbedContent[$lineIndex - 1]
       $waitMatch = [regex]::Match($scrubbedLine, $waitRegex)
       if ($waitMatch.Success) {
+        if ($isRuntimeTagsTest -and $waitMatch.Value -match 'WaitForSeconds') { continue }
         $advisories += (@{
           Path=$rel; Line=$lineIndex; Message="UNH010: real-time wait '$($waitMatch.Value.Trim())' blocks the serial test clock; prefer frame-stepping/deterministic completion/injectable clock (advisory)"
+        })
+      }
+    }
+  }
+
+  # UNH013: Tags runtime tests exercise effect duration, periodic, and
+  # behavior-tick logic that must not depend on Unity's imprecise real-time wait
+  # instructions. Use EffectHandler's deterministic test seams for handler time
+  # math; suppress only when the test is explicitly about Unity lifecycle timing.
+  if ($isRuntimeTagsTest -and $isTestFile -and -not $perfCategory) {
+    $tagsWaitAliases = @()
+    foreach ($aliasMatch in $tagsWaitAliasPattern.Matches($scrubbedText)) {
+      $tagsWaitAliases += [regex]::Escape($aliasMatch.Groups['alias'].Value)
+    }
+    foreach ($aliasMatch in $tagsUnityEngineAliasPattern.Matches($scrubbedText)) {
+      $tagsWaitAliases += (
+        [regex]::Escape($aliasMatch.Groups['alias'].Value) +
+        '\s*(?:\.|::)\s*WaitForSeconds(?:Realtime)?'
+      )
+    }
+    $tagsWaitPatterns = New-Object System.Collections.Generic.List[regex]
+    $tagsWaitPatterns.Add($tagsWaitInstructionPattern)
+    if ($tagsWaitAliases.Count -gt 0) {
+      $tagsWaitPatterns.Add([regex]('\bnew\s+(?:' + ($tagsWaitAliases -join '|') + ')\s*\('))
+    }
+
+    $reportedTagsWaitMatches = @{}
+    foreach ($tagsWaitPattern in $tagsWaitPatterns) {
+      foreach ($waitMatch in $tagsWaitPattern.Matches($scrubbedText)) {
+        $lineIndex = Get-LineNumberAtIndex -Text $scrubbedText -Index $waitMatch.Index
+        $endLineIndex = Get-LineNumberAtIndex -Text $scrubbedText -Index ($waitMatch.Index + [Math]::Max($waitMatch.Length - 1, 0))
+        $matchKey = "$($waitMatch.Index):$($waitMatch.Length)"
+        if ($reportedTagsWaitMatches.ContainsKey($matchKey)) { continue }
+        $reportedTagsWaitMatches[$matchKey] = $true
+        if (
+          Test-CodeSpecificSuppressionInLineRange `
+            -Lines $content `
+            -CommentMaskedLines $commentMaskedContent `
+            -StartLine $lineIndex `
+            -EndLine $endLineIndex `
+            -Code 'UNH013'
+        ) {
+          continue
+        }
+        $violations += (@{
+          Path=$rel; Line=$lineIndex; Message='UNH013: Tests/Runtime/Tags tests must not use WaitForSeconds/WaitForSecondsRealtime; prefer deterministic handler clock seams or add // UNH-SUPPRESS UNH013 with justification'
         })
       }
     }

--- a/scripts/lint-tests.ps1
+++ b/scripts/lint-tests.ps1
@@ -319,7 +319,7 @@ $assertIsNotNullPattern = [regex]'Assert\.IsNotNull\s*\('
 $testCaseDataReturnsNullPattern = [regex]'(?ms)\.Returns\s*\(\s*null\s*\)'
 $unityTestAttributePattern = [regex]'\[\s*(?:global\s*::\s*)?(?:[A-Za-z_][\w\.]*\.)?UnityTest(?:Attribute)?(?:\s*\(|\s*\])'
 $coroutineMethodPattern = [regex]'\bIEnumerator\s+(?<name>\w+)\s*\('
-$tagsWaitInstructionPattern = [regex]'\bnew\s+(?:(?:global\s*::\s*)?UnityEngine\s*(?:\.|::)\s*)?WaitForSeconds(?:Realtime)?\s*\('
+$tagsWaitInstructionPattern = [regex]'WaitForSeconds(?:Realtime)?'
 $tagsWaitAliasPattern = [regex]'(?m)^\s*(?:global\s+)?using\s+(?<alias>[A-Za-z_]\w*)\s*=\s*(?:global\s*::\s*)?UnityEngine\s*(?:\.|::)\s*WaitForSeconds(?:Realtime)?\s*;'
 $tagsUnityEngineAliasPattern = [regex]'(?m)^\s*(?:global\s+)?using\s+(?<alias>[A-Za-z_]\w*)\s*=\s*(?:global\s*::\s*)?UnityEngine\s*;'
 
@@ -1769,7 +1769,7 @@ foreach ($file in $filesToScan) {
   # behavior-tick logic that must not depend on Unity's imprecise real-time wait
   # instructions. Use EffectHandler's deterministic test seams for handler time
   # math; suppress only when the test is explicitly about Unity lifecycle timing.
-  if ($isRuntimeTagsTest -and $isTestFile -and -not $perfCategory) {
+  if ($isRuntimeTagsTest -and -not $perfCategory) {
     $tagsWaitAliases = @()
     foreach ($aliasMatch in $tagsWaitAliasPattern.Matches($scrubbedText)) {
       $tagsWaitAliases += [regex]::Escape($aliasMatch.Groups['alias'].Value)

--- a/scripts/tests/test-lint-tests.ps1
+++ b/scripts/tests/test-lint-tests.ps1
@@ -2000,16 +2000,16 @@ namespace WallstopStudios.UnityHelpers.Tests
 $r = Invoke-LintOnFixture -FixtureRelativePath 'WaitPerfFixture.cs' -FixtureContent $unh010Perf
 Write-TestResult "UNH010.SkipsPerfCategory" (($r.ExitCode -eq 0) -and ($r.Output -notmatch 'UNH010')) "Exit: $($r.ExitCode), Output: $($r.Output)"
 
-# ── UNH011: editor-only refs in player-compiled test code ────────────────────
-Write-Host "`n  Section: UNH011 editor-reference guard" -ForegroundColor White
-
-# UNH011 only governs PLAYER-compiled trees (everything under Tests/ EXCEPT
-# Tests/Editor), so these fixtures live under a Tests/Runtime path.
+# Runtime-path fixtures are shared by UNH011 and UNH013 coverage.
 $tempRuntimeDir = Join-Path $tempDir 'Tests' 'Runtime'
 New-Item -ItemType Directory -Path $tempRuntimeDir -Force | Out-Null
 function Invoke-LintOnRuntimeFixture {
   param([string]$FixtureRelativePath, [string]$FixtureContent)
   $path = Join-Path $tempRuntimeDir $FixtureRelativePath
+  $fixtureDirectory = Split-Path -Parent $path
+  if (-not [string]::IsNullOrWhiteSpace($fixtureDirectory)) {
+    New-Item -ItemType Directory -Path $fixtureDirectory -Force | Out-Null
+  }
   Set-Content -Path $path -Value $FixtureContent -NoNewline
   try {
     Push-Location $tempDir
@@ -2023,6 +2023,377 @@ function Invoke-LintOnRuntimeFixture {
   }
 }
 
+# ── UNH013: Runtime Tags tests must not use literal wait instructions ────────
+Write-Host "`n  Section: UNH013 Tags wait guard" -ForegroundColor White
+
+$unh013WaitForSeconds = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsWaitFixture.cs' -FixtureContent $unh013WaitForSeconds
+Write-TestResult "UNH013.FlagsWaitForSecondsInRuntimeTags" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013UnityTestAttribute = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsUnityTestAttributeWaitFixture : CommonTestBase
+    {
+        [UnityTestAttribute]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsUnityTestAttributeWaitFixture.cs' -FixtureContent $unh013UnityTestAttribute
+Write-TestResult "UNH013.FlagsUnityTestAttributeWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013QualifiedUnityTest = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using UnityEngine;
+
+    public sealed class TagsQualifiedUnityTestWaitFixture : CommonTestBase
+    {
+        [UnityEngine.TestTools.UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsQualifiedUnityTestWaitFixture.cs' -FixtureContent $unh013QualifiedUnityTest
+Write-TestResult "UNH013.FlagsQualifiedUnityTestWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Compact = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags { using System.Collections; using NUnit.Framework; using UnityEngine; using UnityEngine.TestTools; [TestFixture] public sealed class TagsCompactWaitFixture : CommonTestBase { [UnityTest] public IEnumerator Waits() {
+yield return new WaitForSeconds(0.5f); } } }
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsCompactWaitFixture.cs' -FixtureContent $unh013Compact
+Write-TestResult "UNH013.FlagsCompactWaitWithoutStrictModeCrash" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013, not a strict-mode crash. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Realtime = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsRealtimeWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSecondsRealtime(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsRealtimeWaitFixture.cs' -FixtureContent $unh013Realtime
+Write-TestResult "UNH013.FlagsWaitForSecondsRealtimeInRuntimeTags" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013VariableDuration = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsVariableWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            float duration = 0.5f;
+            yield return new WaitForSeconds(duration);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsVariableWaitFixture.cs' -FixtureContent $unh013VariableDuration
+Write-TestResult "UNH013.FlagsVariableDurationConstructor" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Qualified = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsQualifiedWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new UnityEngine.WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsQualifiedWaitFixture.cs' -FixtureContent $unh013Qualified
+Write-TestResult "UNH013.FlagsQualifiedWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013GlobalQualified = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsGlobalQualifiedWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new global::UnityEngine.WaitForSecondsRealtime(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsGlobalQualifiedWaitFixture.cs' -FixtureContent $unh013GlobalQualified
+Write-TestResult "UNH013.FlagsGlobalQualifiedWaitForSecondsRealtime" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Alias = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+    using Wait = UnityEngine.WaitForSeconds;
+
+    public sealed class TagsAliasWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new Wait(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsAliasWaitFixture.cs' -FixtureContent $unh013Alias
+Write-TestResult "UNH013.FlagsAliasedWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013GlobalAlias = @'
+global using Wait = UnityEngine.WaitForSeconds;
+
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsGlobalAliasWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new Wait(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsGlobalAliasWaitFixture.cs' -FixtureContent $unh013GlobalAlias
+Write-TestResult "UNH013.FlagsGlobalAliasedWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013NamespaceAlias = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+    using UE = UnityEngine;
+
+    public sealed class TagsNamespaceAliasWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new UE.WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsNamespaceAliasWaitFixture.cs' -FixtureContent $unh013NamespaceAlias
+Write-TestResult "UNH013.FlagsUnityEngineNamespaceAliasWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013NamespaceAliasQualifier = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine.TestTools;
+    using UE = UnityEngine;
+
+    public sealed class TagsNamespaceAliasQualifierWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new UE::WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsNamespaceAliasQualifierWaitFixture.cs' -FixtureContent $unh013NamespaceAliasQualifier
+Write-TestResult "UNH013.FlagsUnityEngineNamespaceAliasQualifierWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Multiline = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsMultilineWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new
+                WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsMultilineWaitFixture.cs' -FixtureContent $unh013Multiline
+Write-TestResult "UNH013.FlagsMultilineWaitForSeconds" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Suppress = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsSuppressedWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f); // UNH-SUPPRESS UNH013: verifies Unity lifecycle timing.
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsSuppressedWaitFixture.cs' -FixtureContent $unh013Suppress
+Write-TestResult "UNH013.HonorsCodeSpecificSuppress" (($r.ExitCode -eq 0) -and ($r.Output -notmatch 'UNH013')) "Expected exit 0 and no UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013StringSuppress = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsStringSuppressedWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f); string token = "// UNH-SUPPRESS UNH013";
+            Assert.IsTrue(token.Length > 0);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsStringSuppressedWaitFixture.cs' -FixtureContent $unh013StringSuppress
+Write-TestResult "UNH013.IgnoresStringLiteralSuppress" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Performance = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    [Category("Performance")]
+    public sealed class TagsPerformanceWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsPerformanceWaitFixture.cs' -FixtureContent $unh013Performance
+Write-TestResult "UNH013.AllowsPerformanceCategory" (($r.ExitCode -eq 0) -and ($r.Output -notmatch 'UNH013')) "Expected exit 0 and no UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013NonTags = @'
+namespace WallstopStudios.UnityHelpers.Tests.OtherRuntime
+{
+    using System.Collections;
+    using NUnit.Framework;
+    using UnityEngine;
+    using UnityEngine.TestTools;
+
+    public sealed class RuntimeWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'OtherRuntime/RuntimeWaitFixture.cs' -FixtureContent $unh013NonTags
+Write-TestResult "UNH013.AllowsNonTagsRuntimePath" (($r.ExitCode -eq 0) -and ($r.Output -notmatch 'UNH013')) "Expected exit 0 and no UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013Masked = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using NUnit.Framework;
+
+    public sealed class TagsMaskedWaitFixture : CommonTestBase
+    {
+        [Test]
+        public void MentionsOnly()
+        {
+            string sample = "yield return new WaitForSeconds(0.5f);";
+            // yield return new WaitForSecondsRealtime(0.5f);
+            Assert.IsTrue(sample.Length > 0);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsMaskedWaitFixture.cs' -FixtureContent $unh013Masked
+Write-TestResult "UNH013.IgnoresCommentsAndStrings" (($r.ExitCode -eq 0) -and ($r.Output -notmatch 'UNH013')) "Expected exit 0 and no UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+# ── UNH011: editor-only refs in player-compiled test code ────────────────────
+Write-Host "`n  Section: UNH011 editor-reference guard" -ForegroundColor White
+
+# UNH011 only governs PLAYER-compiled trees (everything under Tests/ EXCEPT
+# Tests/Editor), so these fixtures live under a Tests/Runtime path.
 # Unguarded UnityEditor reference in a player-compiled file -> CS0234 -> must fail.
 $unh011Bad = @'
 namespace WallstopStudios.UnityHelpers.Tests

--- a/scripts/tests/test-lint-tests.ps1
+++ b/scripts/tests/test-lint-tests.ps1
@@ -2047,6 +2047,50 @@ namespace WallstopStudios.UnityHelpers.Tests.Tags
 $r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsWaitFixture.cs' -FixtureContent $unh013WaitForSeconds
 Write-TestResult "UNH013.FlagsWaitForSecondsInRuntimeTags" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
 
+$unh013HelperWaitForSeconds = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using UnityEngine;
+
+    internal static class TagsWaitHelper
+    {
+        public static WaitForSeconds CreateWait()
+        {
+            return new WaitForSeconds(0.5f);
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsWaitHelper.cs' -FixtureContent $unh013HelperWaitForSeconds
+Write-TestResult "UNH013.FlagsWaitForSecondsInRuntimeTagsHelper" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
+$unh013CachedApiWaitForSeconds = @'
+namespace WallstopStudios.UnityHelpers.Tests.Tags
+{
+    using System.Collections;
+    using UnityEngine.TestTools;
+
+    public sealed class TagsCachedWaitFixture : CommonTestBase
+    {
+        [UnityTest]
+        public IEnumerator Waits()
+        {
+            yield return TagsWaitBuffers.GetWaitForSeconds(0.5f);
+        }
+    }
+
+    internal static class TagsWaitBuffers
+    {
+        public static object GetWaitForSeconds(float duration)
+        {
+            return null;
+        }
+    }
+}
+'@
+$r = Invoke-LintOnRuntimeFixture -FixtureRelativePath 'Tags/TagsCachedWaitFixture.cs' -FixtureContent $unh013CachedApiWaitForSeconds
+Write-TestResult "UNH013.FlagsCachedWaitForSecondsApiReference" (($r.ExitCode -ne 0) -and ($r.Output -match 'UNH013')) "Expected non-zero exit with UNH013. Exit: $($r.ExitCode), Output: $($r.Output)"
+
 $unh013UnityTestAttribute = @'
 namespace WallstopStudios.UnityHelpers.Tests.Tags
 {


### PR DESCRIPTION
## Summary

Stabilizes Runtime/Tags timing coverage by moving effect duration, periodic behavior, and behavior tick assertions onto deterministic internal clock seams while preserving frame-yield integration coverage for the MonoBehaviour `Update` path. Adds enforced UNH013 lint coverage so non-performance Runtime/Tags tests cannot reintroduce `WaitForSeconds`/`WaitForSecondsRealtime` timing assertions without an explicit lifecycle suppression.

## Root Cause

Unity standalone 6000 IL2CPP failed only the gated standalone leg in run 28609337564. The failed Tags tests asserted exact short real-time wait behavior, but Unity `WaitForSeconds` and `Time.deltaTime` are frame-derived and not exact enough for those assertions in player builds.

A later PR run on head `f0b27765` exposed the same class of fragility in Unity 2021.3 PlayMode: `PeriodicEffectHonorsInitialDelayAndMaxTicks` asserted at an exact float tick boundary (`5.1f`) and saw zero ticks. The follow-up commit moves those deterministic periodic assertions just off exact float boundaries while keeping the production scheduler unchanged.

## Changes

- Added internal `EffectHandler` test seams for supplied `currentTime` and behavior tick `deltaTime` without public API changes.
- Reworked Tags timing tests to use deterministic seams for duration refresh, remaining duration, periodic ticks, and behavior callbacks.
- Kept `Update` wiring covered with a `yield return null` integration assertion that avoids real-time waits.
- Added hard UNH013 lint enforcement and self-tests for direct, qualified, aliased, global, namespace-alias, multiline, helper/API-reference, helper-file, and suppression cases.
- Updated LLM skills documentation for deterministic Tags timing tests and the new linter rule.

## Validation

- `dotnet tool run csharpier format .`
- `pwsh -NoProfile -File scripts/lint-tests.ps1 -FixNullChecks -Paths Tests/Runtime/Tags/AttributeUtilitiesTests.cs Tests/Runtime/Tags/EffectBehaviorTests.cs Tests/Runtime/Tags/EffectHandlerTests.cs`
- `pwsh -NoProfile -File scripts/lint-tests.ps1 -Paths scripts/tests/test-lint-tests.ps1 Tests/Runtime/Tags`
- `pwsh -NoProfile -File scripts/tests/test-lint-tests.ps1 -VerboseOutput` (120 passed, 0 failed)
- `pwsh -NoProfile -File scripts/check-eol.ps1 -Paths scripts/lint-tests.ps1 scripts/tests/test-lint-tests.ps1 Tests/Runtime/Tags/EffectHandlerTests.cs -VerboseOutput`
- `dotnet tool run csharpier format Tests/Runtime/Tags/EffectHandlerTests.cs`
- `pwsh -NoProfile -File scripts/lint-tests.ps1 -Paths Tests/Runtime/Tags/EffectHandlerTests.cs`
- `npm run agent:preflight:fix`
- `npm run validate:prepush`
- Adversarial sub-agent review of the follow-up precision patch found no remaining issues.

Local Unity CLI tests were not run because this devcontainer has no Unity license configured (`scripts/unity/setup-license.ps1 -Check` reports no license). CI standalone 6000 remains the required proof for the original IL2CPP timing failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `EffectHandler` timing paths used in production `Update`, but public API behavior is unchanged; risk is mainly regression in effect duration/periodic/behavior scheduling and new lint false positives in Tags tests.
> 
> **Overview**
> **Stabilizes flaky Runtime/Tags timing tests** by replacing real-time `WaitForSeconds` / frame polling with deterministic `EffectHandler` clock and tick APIs, while keeping one `Update` integration test that only `yield return null`.
> 
> `EffectHandler` now threads an optional `currentTime` through apply/refresh/remaining-duration and periodic registration; public entry points still use `Time.time`. New **internal** seams include `ApplyEffectForTesting`, overloads of `TryGetRemainingDuration` / `EnsureHandle` / `RefreshEffect` with `currentTime`, `ProcessBehaviorTicksForTesting`, and existing `ProcessPeriodicEffectsForTesting`—behavior tick processing returns a tick count.
> 
> **Tags test suites** (`EffectHandlerTests`, `EffectBehaviorTests`, `AttributeUtilitiesTests`) assert duration, periodic, and behavior semantics via those seams; several `UnityTest` cases became synchronous `[Test]` where waits were only for time math.
> 
> **Lint and docs:** **UNH013** blocks non-performance `Tests/Runtime/Tags` code from constructing `WaitForSeconds` / `WaitForSecondsRealtime` (aliases, multiline, helpers included), with `// UNH-SUPPRESS UNH013` support via comment-aware suppression helpers; extensive fixtures in `test-lint-tests.ps1`. Skills reference **UNH013** and the deterministic testing pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55377da656fb0fa81f5f96cebbf894872b1bd2cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->