### PR TITLE
bugfix: Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wallstop/unity-helpers.git"
+    "url": "git+https://github.com/Ambiguous-Interactive/unity-helpers.git"
   },
   "bugs": {
-    "url": "https://github.com/wallstop/unity-helpers/issues"
+    "url": "https://github.com/Ambiguous-Interactive/unity-helpers/issues"
   },
   "signature": "unsigned",
   "author": "wallstop studios <wallstop@wallstopstudios.com> (https://wallstopstudios.com)",


### PR DESCRIPTION
## Description

Fix package.json URLs to new github owner path

## Related Issue

<!-- Link to the issue this PR addresses -->

Fixes #

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)

## Checklist

<!-- Ensure all items are completed before requesting review -->

- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have updated the [CHANGELOG](../CHANGELOG.md)
- [ ] My changes do not introduce breaking changes, or breaking changes are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only URL changes with no runtime or package behavior impact.
> 
> **Overview**
> Updates **`package.json`** metadata so the **git repository** and **bugs** links use `github.com/Ambiguous-Interactive/unity-helpers` instead of `github.com/wallstop/unity-helpers`, matching the org move reflected elsewhere in the package (e.g. homepage/docs URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5557310d387ac8cb811e9b8695c0e4b16f25a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->