### PR TITLE
Use build lock App credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,13 +346,15 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "210"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Export Unity package
         env:
@@ -378,12 +380,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity export log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
             echo "latest-version=${latest}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required Unity license secrets
+      - name: Check for required secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -61,7 +61,7 @@ jobs:
             echo "latest-version=${latest}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required secrets
+      - name: Check for required licensed workflow secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -67,13 +67,15 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          ORG_BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${UNITY_SERIAL:-}" ] && \
              [ -n "${UNITY_EMAIL:-}" ] && \
              [ -n "${UNITY_PASSWORD:-}" ] && \
-             [ -n "${ORG_BUILD_LOCK_TOKEN:-}" ]; then
+             [ -n "${BUILD_LOCK_APP_ID:-}" ] && \
+             [ -n "${BUILD_LOCK_APP_PRIVATE_KEY:-}" ]; then
             echo "has-secrets=true" >> "${GITHUB_OUTPUT}"
           else
             echo "has-secrets=false" >> "${GITHUB_OUTPUT}"
@@ -323,13 +325,15 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -396,12 +400,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -149,13 +149,15 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          ORG_BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           if [ -n "${UNITY_SERIAL:-}" ] && \
              [ -n "${UNITY_EMAIL:-}" ] && \
              [ -n "${UNITY_PASSWORD:-}" ] && \
-             [ -n "${ORG_BUILD_LOCK_TOKEN:-}" ]; then
+             [ -n "${BUILD_LOCK_APP_ID:-}" ] && \
+             [ -n "${BUILD_LOCK_APP_PRIVATE_KEY:-}" ]; then
             echo "has-secrets=true" >> "${GITHUB_OUTPUT}"
           else
             echo "has-secrets=false" >> "${GITHUB_OUTPUT}"
@@ -475,13 +477,15 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -542,12 +546,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
       # step times out (or the operator cancels), and the verify step below
@@ -804,13 +810,15 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -871,12 +879,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       # CANCELLATION + TIMEOUT DIAGNOSTIC: when Unity hangs in csc the runner
       # step times out (or the operator cancels), and the verify step below
@@ -1118,13 +1128,15 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
+          runner-id: ${{ runner.name }}
           timeout-minutes: "300"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Run Unity Test Runner
         id: run_tests
@@ -1180,12 +1192,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}
@@ -1261,13 +1275,15 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
+          runner-id: ${{ runner.name }}
           timeout-minutes: "210"
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Export Unity package smoke artifact
         timeout-minutes: 120
@@ -1295,12 +1311,14 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
+          runner-id: ${{ runner.name }}
         env:
-          BUILD_LOCK_TOKEN: ${{ secrets.ORG_BUILD_LOCK_TOKEN }}
+          BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
+          BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Dump Unity export log tail on failure or cancellation
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -143,7 +143,7 @@ jobs:
             echo "matrix-include-standalone=${include_std}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required secrets
+      - name: Check for required licensed workflow secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -143,7 +143,7 @@ jobs:
             echo "matrix-include-standalone=${include_std}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Check for required Unity license secrets
+      - name: Check for required secrets
         id: check-secrets
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/docs/runbooks/unity-runners-after-transfer.md
+++ b/docs/runbooks/unity-runners-after-transfer.md
@@ -200,6 +200,6 @@ Re-run the queued Unity workflow once the bootstrap run completes successfully o
 The Unity workflows expect the following repository (or organization) secrets. They are NOT provisioned by this batch; a maintainer must add them before the first self-hosted run:
 
 - `UNITY_SERIAL`, `UNITY_EMAIL`, `UNITY_PASSWORD` — classic serial Unity activation (all three required together).
-- `ORG_BUILD_LOCK_TOKEN` — token for the `wallstop-organization-builds` org build lock (`Ambiguous-Interactive/ambiguous-organization-build-lock`).
+- `BUILD_LOCK_APP_ID`, `BUILD_LOCK_APP_PRIVATE_KEY` — dedicated GitHub App credentials for the `wallstop-organization-builds` organization build lock (`Ambiguous-Interactive/ambiguous-organization-build-lock`); both are required together and should be provisioned as organization secrets with access to this repository.
 - `UNITY_ACCELERATOR_ENDPOINT` — optional; enables the Unity Accelerator cache namespace when set.
 - `RUNNER_AUDIT_PAT` — optional; upgrades the runner-preflight soft pass to a hard pass (see above).

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -250,8 +250,8 @@ function Test-UnityLockCleanupIsGated {
         [Parameter(Mandatory = $true)][string]$WorkflowFile
     )
 
-    $acquireUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1.2.0'
-    $releaseUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1.2.0'
+    $acquireUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
+    $releaseUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
     $returnUses = './.github/actions/return-unity-license'
     $requiredGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
 
@@ -291,6 +291,59 @@ function Test-UnityLockCleanupIsGated {
 
     if ($failures.Count -gt 0) {
         Write-Host "::error file=$WorkflowFile::Unity lock cleanup contract failed: $($failures -join '; ')"
+        return $false
+    }
+
+    return $true
+}
+
+function Test-UnityLockAppConfiguration {
+    param(
+        [Parameter(Mandatory = $true)][string]$Content,
+        [Parameter(Mandatory = $true)][string]$WorkflowFile
+    )
+
+    $lockSteps = @(
+        [regex]::Matches(
+            $Content,
+            '(?ms)^\s+- name: (?:Acquire|Release) organization Unity lock\s*$.*?(?=^\s+- name:|\z)'
+        )
+    )
+    $failures = @()
+
+    if ($lockSteps.Count -eq 0) {
+        $failures += 'workflow must contain at least one Unity lock step'
+    }
+
+    foreach ($lockStep in $lockSteps) {
+        $stepText = $lockStep.Value
+        $expectedAction = if ($stepText.Contains('Acquire organization Unity lock')) {
+            'acquire-build-lock@v1'
+        } else {
+            'release-build-lock@v1'
+        }
+
+        if (-not $stepText.Contains($expectedAction)) {
+            $failures += "lock step must use $expectedAction"
+        }
+        if ($stepText -notmatch '(?m)^\s+runner-id:\s+\$\{\{ runner\.name \}\}\s*$') {
+            $failures += 'lock step must pass runner-id from runner.name'
+        }
+        if ($stepText -notmatch '(?m)^\s+BUILD_LOCK_APP_ID:\s+\$\{\{ secrets\.BUILD_LOCK_APP_ID \}\}\s*$') {
+            $failures += 'lock step must pass the GitHub App ID secret'
+        }
+        if ($stepText -notmatch '(?m)^\s+BUILD_LOCK_APP_PRIVATE_KEY:\s+\$\{\{ secrets\.BUILD_LOCK_APP_PRIVATE_KEY \}\}\s*$') {
+            $failures += 'lock step must pass the GitHub App private key secret'
+        }
+    }
+
+    $legacyTokenPattern = '(?:ORG_)?BUILD_LOCK_' + 'TOKEN'
+    if ($Content -match $legacyTokenPattern) {
+        $failures += 'legacy build lock tokens must not be referenced'
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host "::error file=$WorkflowFile::Unity lock App configuration contract failed: $($failures -join '; ')"
         return $false
     }
 
@@ -1976,6 +2029,17 @@ if (-not $unityLockCleanupIsGated) {
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info "Checked Unity lock cleanup runs only after acquisition and before release."
+}
+
+$unityLockUsesAppCredentials = (
+    (Test-UnityLockAppConfiguration -Content $workflowContent -WorkflowFile '.github/workflows/unity-tests.yml') -and
+    (Test-UnityLockAppConfiguration -Content ($benchmarksWorkflowLines -join "`n") -WorkflowFile '.github/workflows/unity-benchmarks.yml') -and
+    (Test-UnityLockAppConfiguration -Content ($releaseWorkflowLines -join "`n") -WorkflowFile '.github/workflows/release.yml')
+)
+if (-not $unityLockUsesAppCredentials) {
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info "Checked Unity lock steps use matching runner identity and GitHub App credentials."
 }
 
 $slowReportBudgetCount = ([regex]::Matches($workflowContent, [regex]::Escape('-FixtureBudgetSeconds 120'))).Count

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -255,9 +255,9 @@ function Test-UnityLockCleanupIsGated {
     $returnUses = './.github/actions/return-unity-license'
     $requiredGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
 
-    $acquirePattern = '(?ms)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:.*?\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses)
+    $acquirePattern = '(?ms)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:.*?\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + '[ \t]*\r?$'
     $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
-    $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses)
+    $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + '[ \t]*\r?$'
     $failures = @()
 
     foreach ($job in $Jobs.GetEnumerator()) {
@@ -318,12 +318,13 @@ function Test-UnityLockAppConfiguration {
     foreach ($lockStep in $lockSteps) {
         $stepText = $lockStep.Value
         $expectedAction = if ($stepText.Contains('Acquire organization Unity lock')) {
-            'acquire-build-lock@v1'
+            'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
         } else {
-            'release-build-lock@v1'
+            'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
         }
 
-        if (-not $stepText.Contains($expectedAction)) {
+        $exactActionPattern = '(?m)^\s+uses:\s+' + [regex]::Escape($expectedAction) + '[ \t]*\r?$'
+        if ($stepText -notmatch $exactActionPattern) {
             $failures += "lock step must use $expectedAction"
         }
         if ($stepText -notmatch '(?m)^\s+runner-id:\s+\$\{\{ runner\.name \}\}\s*$') {

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2045,6 +2045,19 @@ if (-not $unityLockUsesAppCredentials) {
     Write-Info "Checked Unity lock steps use matching runner identity and GitHub App credentials."
 }
 
+$legacyOrganizationLockToken = 'ORG_BUILD_LOCK_' + 'TOKEN'
+$unityLockRunbookUsesAppCredentials = (
+    $runnerRunbookContent.Contains('`BUILD_LOCK_APP_ID`') -and
+    $runnerRunbookContent.Contains('`BUILD_LOCK_APP_PRIVATE_KEY`') -and
+    -not $runnerRunbookContent.Contains($legacyOrganizationLockToken)
+)
+if (-not $unityLockRunbookUsesAppCredentials) {
+    Write-Host "::error file=docs/runbooks/unity-runners-after-transfer.md::Unity runner runbook must provision both build-lock GitHub App secrets and must not reference the legacy organization PAT."
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info "Checked Unity runner runbook provisions GitHub App credentials for the organization build lock."
+}
+
 $slowReportBudgetCount = ([regex]::Matches($workflowContent, [regex]::Escape('-FixtureBudgetSeconds 120'))).Count
 if ($slowReportBudgetCount -lt 3) {
     Write-Host "::error file=.github/workflows/unity-tests.yml::Unity slow-test reports must include a warn-only 120s fixture budget for main, standalone, and single-threaded legs."

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -317,7 +317,9 @@ function Test-UnityLockAppConfiguration {
 
     foreach ($lockStep in $lockSteps) {
         $stepText = $lockStep.Value
-        $expectedAction = if ($stepText.Contains('Acquire organization Unity lock')) {
+        $isAcquireStep = $stepText.Contains('Acquire organization Unity lock')
+        $stepKind = if ($isAcquireStep) { 'Acquire' } else { 'Release' }
+        $expectedAction = if ($isAcquireStep) {
             'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
         } else {
             'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
@@ -325,16 +327,16 @@ function Test-UnityLockAppConfiguration {
 
         $exactActionPattern = '(?m)^\s+uses:\s+' + [regex]::Escape($expectedAction) + '[ \t]*\r?$'
         if ($stepText -notmatch $exactActionPattern) {
-            $failures += "lock step must use $expectedAction"
+            $failures += "$stepKind lock step must use $expectedAction"
         }
         if ($stepText -notmatch '(?m)^\s+runner-id:\s+\$\{\{ runner\.name \}\}\s*$') {
-            $failures += 'lock step must pass runner-id from runner.name'
+            $failures += "$stepKind lock step must pass runner-id from runner.name"
         }
         if ($stepText -notmatch '(?m)^\s+BUILD_LOCK_APP_ID:\s+\$\{\{ secrets\.BUILD_LOCK_APP_ID \}\}\s*$') {
-            $failures += 'lock step must pass the GitHub App ID secret'
+            $failures += "$stepKind lock step must pass the GitHub App ID secret"
         }
         if ($stepText -notmatch '(?m)^\s+BUILD_LOCK_APP_PRIVATE_KEY:\s+\$\{\{ secrets\.BUILD_LOCK_APP_PRIVATE_KEY \}\}\s*$') {
-            $failures += 'lock step must pass the GitHub App private key secret'
+            $failures += "$stepKind lock step must pass the GitHub App private key secret"
         }
     }
 


### PR DESCRIPTION
## Summary

- migrate every Unity lock acquire/release pair to the compatible `@v1` action
- pass `${{ runner.name }}` consistently as the physical runner identity
- replace the organization PAT with renewable GitHub App credentials
- extend the workflow contract to prevent version, runner identity, credential, and PAT regressions

## Why

The organization build lock is moving to App-only authentication and runner-aware serialization. All active consumer call sites must be compatible before serialization is enabled.

## Validation

- `npm run agent:preflight:fix`
- `npm run test:unity-workflow-matrix-contract`
- `actionlint -shellcheck= -pyflakes= -config-file .github/actionlint.yaml` for the three changed workflows
- Prettier YAML formatting check
- workflow test lint
- EOL and `git diff --check`

The broader local suite reached existing Windows fixture failures in `test-gitignore-docs`; PR CI is the authoritative Linux validation run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all licensed Unity CI paths and depend on org secrets and the external lock action; misconfiguration would block releases and tests, but scope is workflow/config only with no application runtime changes.
> 
> **Overview**
> Unity CI switches the **wallstop-organization-builds** lock from a legacy org PAT to **GitHub App** secrets (`BUILD_LOCK_APP_ID`, `BUILD_LOCK_APP_PRIVATE_KEY`), bumps acquire/release actions from `@v1.2.0` to **`@v1`**, and passes **`runner-id: ${{ runner.name }}`** on every lock step so the lock service can tie holders to physical runners.
> 
> **release.yml**, **unity-tests.yml**, and **unity-benchmarks.yml** apply that pattern on all acquire/release pairs; licensed-workflow secret gates now require the App pair instead of `ORG_BUILD_LOCK_TOKEN`. The unity runner runbook documents the new secrets and drops the PAT.
> 
> **test-unity-workflow-matrix-contract.ps1** adds `Test-UnityLockAppConfiguration` (action pin, `runner-id`, App env, no legacy tokens) and tightens lock-step regexes; it also asserts the runbook matches the App credential contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce1ab2f8913a3cd703fa8ab01aa802e9aa338df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->