### PR TITLE
fix(ci): prove Unity cleanup before lock release

### DIFF
--- a/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
+++ b/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
@@ -1,0 +1,39 @@
+Set-StrictMode -Version Latest
+
+function Test-UnityLicenseReturnResourceSafe {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][int]$ExitCode,
+        [Parameter(Mandatory = $true)][string]$LogPath
+    )
+
+    if ($ExitCode -eq 0) {
+        return $true
+    }
+
+    # Process termination is never proof of cleanup, even if a partial/stale log
+    # happens to contain Unity's normal success markers.
+    if ($ExitCode -in @(137, 143, -1073741510, -1073740791)) {
+        return $false
+    }
+
+    try {
+        if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
+            return $false
+        }
+
+        $lines = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::Ordinal
+        )
+        foreach ($line in (Get-Content -LiteralPath $LogPath -ErrorAction Stop)) {
+            [void]$lines.Add(([string]$line).Trim())
+        }
+
+        return (
+            $lines.Contains('Successfully returned the entitlement license') -and
+            $lines.Contains('Serial number unavailable for ULF return')
+        )
+    } catch {
+        return $false
+    }
+}

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -9,10 +9,15 @@ inputs:
   unity-editor-path:
     description: "Path to the resolved Unity editor exe (exported to GITHUB_ENV by run-ci-tests.ps1). When empty there is nothing to return."
     required: false
+outputs:
+  resource-safe:
+    description: "Whether Unity confirmed that this runner no longer holds the license activation."
+    value: ${{ steps.return_license.outputs.resource-safe }}
 runs:
   using: composite
   steps:
     - name: Return Unity license
+      id: return_license
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
@@ -32,6 +37,7 @@ runs:
         # also reclaimed by the NEXT run's return-at-start even if every branch
         # below is skipped.
         try {
+          "resource-safe=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           $editorPath = '${{ inputs.unity-editor-path }}'
           if ([string]::IsNullOrWhiteSpace($editorPath)) {
             $editorPath = $env:UNITY_EDITOR_PATH
@@ -109,11 +115,13 @@ runs:
             }
 
             if ($returnedEntitlement -and $legacyFileUnavailable) {
+              "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
               Write-Host "::notice::Unity returned the entitlement license, then exited with code $exitCode while skipping legacy ULF return; treating the seat return as successful."
             } else {
               Write-Host "::warning::Unity license return exited with code $exitCode; the next run's return-at-start is the backstop for the leaked seat."
             }
           } else {
+            "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
             Write-Host "::notice::Returned the Unity license seat."
           }
         } catch {

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -21,6 +21,7 @@ runs:
       shell: pwsh
       run: |
         Set-StrictMode -Version Latest
+        . (Join-Path '${{ github.action_path }}' 'Classify-UnityLicenseReturn.ps1')
         # Pin $PSNativeCommandUseErrorActionPreference = $false (mirrors the
         # rationale in scripts/unity/run-ci-tests.ps1). PowerShell 7.4+
         # can ENABLE the native-error behavior so that `& <native>` THROWS on a
@@ -94,27 +95,7 @@ runs:
           Write-Host "::endgroup::"
 
           if ($exitCode -ne 0) {
-            $returnedEntitlement = $false
-            $legacyFileUnavailable = $false
-            try {
-              if (Test-Path -LiteralPath $returnLog -PathType Leaf) {
-                $returnedEntitlement = Select-String `
-                  -LiteralPath $returnLog `
-                  -Pattern 'Successfully returned the entitlement license' `
-                  -SimpleMatch `
-                  -Quiet
-                $legacyFileUnavailable = Select-String `
-                  -LiteralPath $returnLog `
-                  -Pattern 'Serial number unavailable for ULF return' `
-                  -SimpleMatch `
-                  -Quiet
-              }
-            } catch {
-              $returnedEntitlement = $false
-              $legacyFileUnavailable = $false
-            }
-
-            if ($returnedEntitlement -and $legacyFileUnavailable) {
+            if (Test-UnityLicenseReturnResourceSafe -ExitCode $exitCode -LogPath $returnLog) {
               "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
               Write-Host "::notice::Unity returned the entitlement license, then exited with code $exitCode while skipping legacy ULF return; treating the seat return as successful."
             } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,6 +372,7 @@ jobs:
           bash scripts/unity/export-unitypackage.sh --output "${output}"
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -385,6 +386,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,13 +374,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -394,13 +394,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -392,6 +392,7 @@ jobs:
             -ArtifactsPath '.artifacts/unity/benchmarks-random/${{ matrix.unity-version }}'
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -405,6 +406,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -538,6 +538,7 @@ jobs:
           }
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -551,6 +552,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -871,6 +873,7 @@ jobs:
           }
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -884,6 +887,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -1184,6 +1188,7 @@ jobs:
           }
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -1197,6 +1202,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -1303,6 +1309,7 @@ jobs:
             --output "${output}"
 
       - name: Return Unity license
+        id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
         uses: ./.github/actions/return-unity-license
         env:
@@ -1316,6 +1323,7 @@ jobs:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
           runner-id: ${{ runner.name }}
+          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -540,13 +540,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
@@ -875,13 +877,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
@@ -1190,13 +1194,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds
@@ -1311,13 +1317,15 @@ jobs:
       - name: Return Unity license
         id: return_unity_license
         if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        timeout-minutes: 5
+        continue-on-error: true
         uses: ./.github/actions/return-unity-license
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
-        if: ${{ always() && steps.unity_lock.outcome == 'success' }}
+        if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
         uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
         with:
           lock-name: wallstop-organization-builds

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -45,6 +45,7 @@ $runnerBootstrapPath = Join-Path $repoRoot '.github/workflows/runner-bootstrap.y
 $actionlintPath = Join-Path $repoRoot '.github/actionlint.yaml'
 $runnerRunbookPath = Join-Path $repoRoot 'docs/runbooks/unity-runners-after-transfer.md'
 $runnerDiagnosticsActionPath = Join-Path $repoRoot '.github/actions/print-self-hosted-runner-diagnostics/action.yml'
+$returnUnityLicenseActionPath = Join-Path $repoRoot '.github/actions/return-unity-license/action.yml'
 $unityVersionsPath = Join-Path $repoRoot '.github/unity-versions.json'
 $integrationPackagesPath = Join-Path $repoRoot '.github/integration-packages.json'
 $windowsRunnerBootstrapPath = Join-Path $repoRoot 'scripts/unity/bootstrap-windows-runner.ps1'
@@ -78,6 +79,10 @@ if (-not (Test-Path -LiteralPath $runnerRunbookPath)) {
 }
 if (-not (Test-Path -LiteralPath $runnerDiagnosticsActionPath)) {
     Write-Host "::error::Self-hosted runner diagnostics action not found: $runnerDiagnosticsActionPath"
+    exit 1
+}
+if (-not (Test-Path -LiteralPath $returnUnityLicenseActionPath)) {
+    Write-Host "::error::Return Unity license action not found: $returnUnityLicenseActionPath"
     exit 1
 }
 if (-not (Test-Path -LiteralPath $unityVersionsPath)) {
@@ -247,7 +252,8 @@ function Get-WorkflowJobTexts {
 function Test-UnityLockCleanupIsGated {
     param(
         [Parameter(Mandatory = $true)][hashtable]$Jobs,
-        [Parameter(Mandatory = $true)][string]$WorkflowFile
+        [Parameter(Mandatory = $true)][string]$WorkflowFile,
+        [Parameter(Mandatory = $true)][hashtable]$LicensedWorkStepNames
     )
 
     $acquireUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
@@ -256,7 +262,7 @@ function Test-UnityLockCleanupIsGated {
     $requiredGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
 
     $acquirePattern = '(?ms)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:.*?\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + '[ \t]*\r?$'
-    $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
+    $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
     $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + '[ \t]*\r?$'
     $failures = @()
 
@@ -274,18 +280,44 @@ function Test-UnityLockCleanupIsGated {
         $acquireIndex = $jobText.IndexOf('- name: Acquire organization Unity lock', [StringComparison]::Ordinal)
         $returnIndex = $jobText.IndexOf('- name: Return Unity license', [StringComparison]::Ordinal)
         $releaseIndex = $jobText.IndexOf('- name: Release organization Unity lock', [StringComparison]::Ordinal)
+        [string[]]$declaredLicensedWorkSteps = if ($LicensedWorkStepNames.ContainsKey($job.Key)) {
+            @($LicensedWorkStepNames[$job.Key] | ForEach-Object { [string]$_ })
+        } else {
+            @()
+        }
+        $acquireStep = [regex]::Match($jobText, '(?ms)^\s+- name: Acquire organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
+        $releaseStep = [regex]::Match($jobText, '(?ms)^\s+- name: Release organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
+        $acquireHolder = [regex]::Match($acquireStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
+        $releaseHolder = [regex]::Match($releaseStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
+        $acquireRunner = [regex]::Match($acquireStep.Value, '(?m)^\s+runner-id:\s*(?<value>[^\r\n]+)')
+        $releaseRunner = [regex]::Match($releaseStep.Value, '(?m)^\s+runner-id:\s*(?<value>[^\r\n]+)')
 
         if ($jobText -notmatch $acquirePattern) {
             $failures += "$($job.Key): acquire step must have id unity_lock before uses"
         }
         if ($jobText -notmatch $returnPattern) {
-            $failures += "$($job.Key): return-unity-license must be gated on successful unity_lock acquisition"
+            $failures += "$($job.Key): return-unity-license must be identified and gated on successful unity_lock acquisition"
         }
         if ($jobText -notmatch $releasePattern) {
             $failures += "$($job.Key): release-build-lock must be gated on successful unity_lock acquisition"
         }
-        if (-not (0 -le $acquireIndex -and $acquireIndex -lt $returnIndex -and $returnIndex -lt $releaseIndex)) {
-            $failures += "$($job.Key): lock cleanup order must be acquire, return Unity license, then release lock"
+        if ($declaredLicensedWorkSteps.Count -eq 0) {
+            $failures += "$($job.Key): every lock-owning job must declare at least one licensed-work step"
+        }
+        foreach ($licensedWorkStepName in $declaredLicensedWorkSteps) {
+            $licensedWorkIndex = $jobText.IndexOf("- name: $licensedWorkStepName", [StringComparison]::Ordinal)
+            if (-not (0 -le $acquireIndex -and $acquireIndex -lt $licensedWorkIndex -and $licensedWorkIndex -lt $returnIndex -and $returnIndex -lt $releaseIndex)) {
+                $failures += "$($job.Key): lock lifecycle order must be acquire, licensed work '$licensedWorkStepName', identified cleanup, then release"
+            }
+        }
+        if (-not $acquireHolder.Success -or -not $releaseHolder.Success -or $acquireHolder.Groups['value'].Value.Trim() -ne $releaseHolder.Groups['value'].Value.Trim()) {
+            $failures += "$($job.Key): acquire and release must use the same holder-id-suffix"
+        }
+        if (-not $acquireRunner.Success -or -not $releaseRunner.Success -or $acquireRunner.Groups['value'].Value.Trim() -ne $releaseRunner.Groups['value'].Value.Trim()) {
+            $failures += "$($job.Key): acquire and release must use the same runner-id"
+        }
+        if ($releaseStep.Value -notmatch '(?m)^\s+resource-safe:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-safe \}\}\s*$') {
+            $failures += "$($job.Key): release must pass the identified cleanup resource-safe output"
         }
     }
 
@@ -362,6 +394,7 @@ function Test-UnityLockAppConfiguration {
 [string]$actionlintContent = Get-Content -LiteralPath $actionlintPath -Raw
 [string]$runnerRunbookContent = Get-Content -LiteralPath $runnerRunbookPath -Raw
 [string]$runnerDiagnosticsActionContent = Get-Content -LiteralPath $runnerDiagnosticsActionPath -Raw
+[string]$returnUnityLicenseActionContent = Get-Content -LiteralPath $returnUnityLicenseActionPath -Raw
 [string]$windowsRunnerBootstrapContent = Get-Content -LiteralPath $windowsRunnerBootstrapPath -Raw
 [string]$windowsRunnerMaintenanceContent = Get-Content -LiteralPath $windowsRunnerMaintenancePath -Raw
 [string]$ensureEditorContent = Get-Content -LiteralPath $ensureEditorPath -Raw
@@ -2024,14 +2057,57 @@ if (-not $unityMatrixParallelismUsesRunnerSlots) {
 }
 
 $unityLockCleanupIsGated = (
-    (Test-UnityLockCleanupIsGated -Jobs $jobTexts -WorkflowFile '.github/workflows/unity-tests.yml') -and
-    (Test-UnityLockCleanupIsGated -Jobs $benchmarksJobTexts -WorkflowFile '.github/workflows/unity-benchmarks.yml') -and
-    (Test-UnityLockCleanupIsGated -Jobs $releaseJobTexts -WorkflowFile '.github/workflows/release.yml')
+    (Test-UnityLockCleanupIsGated `
+            -Jobs $jobTexts `
+            -WorkflowFile '.github/workflows/unity-tests.yml' `
+            -LicensedWorkStepNames @{
+                'unity-tests' = 'Run Unity Test Runner'
+                'unity-tests-standalone' = 'Run Unity Test Runner'
+                'unity-tests-single-threaded' = 'Run Unity Test Runner'
+                'unitypackage-smoke' = 'Export Unity package smoke artifact'
+            }) -and
+    (Test-UnityLockCleanupIsGated `
+            -Jobs $benchmarksJobTexts `
+            -WorkflowFile '.github/workflows/unity-benchmarks.yml' `
+            -LicensedWorkStepNames @{
+                benchmarks = @(
+                    'Run Unity Test Runner'
+                    'Run Random suite at full sample count'
+                )
+            }) -and
+    (Test-UnityLockCleanupIsGated `
+            -Jobs $releaseJobTexts `
+            -WorkflowFile '.github/workflows/release.yml' `
+            -LicensedWorkStepNames @{ unitypackage = 'Export Unity package' })
 )
 if (-not $unityLockCleanupIsGated) {
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info "Checked Unity lock cleanup runs only after acquisition and before release."
+}
+
+$resourceSafeFalseAssignments = [regex]::Matches(
+    $returnUnityLicenseActionContent,
+    '(?m)^\s+"resource-safe=false"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$'
+)
+$resourceSafeTrueAssignments = [regex]::Matches(
+    $returnUnityLicenseActionContent,
+    '(?m)^\s+"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$'
+)
+$returnActionResourceProofContract = (
+    $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-safe:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-safe \}\}\s*$' -and
+    $returnUnityLicenseActionContent -match '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_license\s*\r?\n' -and
+    $resourceSafeFalseAssignments.Count -eq 1 -and
+    $resourceSafeTrueAssignments.Count -eq 2 -and
+    $returnUnityLicenseActionContent -match '(?ms)try \{\s*"resource-safe=false"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
+    $returnUnityLicenseActionContent -match '(?ms)if \(\$returnedEntitlement -and \$legacyFileUnavailable\) \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
+    $returnUnityLicenseActionContent -match '(?ms)\} else \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s+Write-Host "::notice::Returned the Unity license seat\."'
+)
+if (-not $returnActionResourceProofContract) {
+    Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default resource-safe to false and set it true only for exit code zero or the existing dual-marker allowlist.'
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info 'Checked return action emits conservative, non-masking cleanup proof.'
 }
 
 $unityLockUsesAppCredentials = (

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -46,6 +46,7 @@ $actionlintPath = Join-Path $repoRoot '.github/actionlint.yaml'
 $runnerRunbookPath = Join-Path $repoRoot 'docs/runbooks/unity-runners-after-transfer.md'
 $runnerDiagnosticsActionPath = Join-Path $repoRoot '.github/actions/print-self-hosted-runner-diagnostics/action.yml'
 $returnUnityLicenseActionPath = Join-Path $repoRoot '.github/actions/return-unity-license/action.yml'
+$returnUnityLicenseClassifierPath = Join-Path $repoRoot '.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1'
 $unityVersionsPath = Join-Path $repoRoot '.github/unity-versions.json'
 $integrationPackagesPath = Join-Path $repoRoot '.github/integration-packages.json'
 $windowsRunnerBootstrapPath = Join-Path $repoRoot 'scripts/unity/bootstrap-windows-runner.ps1'
@@ -259,11 +260,12 @@ function Test-UnityLockCleanupIsGated {
     $acquireUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
     $releaseUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
     $returnUses = './.github/actions/return-unity-license'
-    $requiredGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
+    $requiredCleanupGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
+    $requiredReleaseGate = 'if: ${{ always() && (steps.unity_lock.outcome == ''success'' || steps.unity_lock.outcome == ''failure'' || steps.unity_lock.outcome == ''cancelled'') }}'
 
     $acquirePattern = '(?ms)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:.*?\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + '[ \t]*\r?$'
-    $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
-    $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + '[ \t]*\r?$'
+    $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredCleanupGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+continue-on-error:\s+true\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
+    $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredReleaseGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + '[ \t]*\r?$'
     $failures = @()
 
     foreach ($job in $Jobs.GetEnumerator()) {
@@ -296,10 +298,10 @@ function Test-UnityLockCleanupIsGated {
             $failures += "$($job.Key): acquire step must have id unity_lock before uses"
         }
         if ($jobText -notmatch $returnPattern) {
-            $failures += "$($job.Key): return-unity-license must be identified and gated on successful unity_lock acquisition"
+            $failures += "$($job.Key): return-unity-license must be identified, success-gated, bounded to five minutes, and non-masking"
         }
         if ($jobText -notmatch $releasePattern) {
-            $failures += "$($job.Key): release-build-lock must be gated on successful unity_lock acquisition"
+            $failures += "$($job.Key): release-build-lock must run after every non-skipped acquire outcome"
         }
         if ($declaredLicensedWorkSteps.Count -eq 0) {
             $failures += "$($job.Key): every lock-owning job must declare at least one licensed-work step"
@@ -2099,15 +2101,52 @@ $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_license\s*\r?\n' -and
     $resourceSafeFalseAssignments.Count -eq 1 -and
     $resourceSafeTrueAssignments.Count -eq 2 -and
+    $returnUnityLicenseActionContent -match [regex]::Escape('. (Join-Path ''${{ github.action_path }}'' ''Classify-UnityLicenseReturn.ps1'')') -and
     $returnUnityLicenseActionContent -match '(?ms)try \{\s*"resource-safe=false"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
-    $returnUnityLicenseActionContent -match '(?ms)if \(\$returnedEntitlement -and \$legacyFileUnavailable\) \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
+    $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
     $returnUnityLicenseActionContent -match '(?ms)\} else \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s+Write-Host "::notice::Returned the Unity license seat\."'
 )
 if (-not $returnActionResourceProofContract) {
-    Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default resource-safe to false and set it true only for exit code zero or the existing dual-marker allowlist.'
+    Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default resource-safe to false and set it true only for exit code zero or the strict classifier allowlist.'
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked return action emits conservative, non-masking cleanup proof.'
+}
+
+$classificationCases = @(
+    @{ Name = 'zero exit'; ExitCode = 0; Lines = @(); Expected = $true }
+    @{ Name = 'dual exact normalized markers'; ExitCode = 1; Lines = @('  Successfully returned the entitlement license  ', "`tSerial number unavailable for ULF return"); Expected = $true }
+    @{ Name = 'generic success'; ExitCode = 1; Lines = @('License return succeeded'); Expected = $false }
+    @{ Name = 'one marker'; ExitCode = 1; Lines = @('Successfully returned the entitlement license'); Expected = $false }
+    @{ Name = 'negated marker substrings'; ExitCode = 1; Lines = @('Not Successfully returned the entitlement license', 'Not Serial number unavailable for ULF return'); Expected = $false }
+    @{ Name = 'terminated despite exact markers'; ExitCode = 137; Lines = @('Successfully returned the entitlement license', 'Serial number unavailable for ULF return'); Expected = $false }
+    @{ Name = 'missing log'; ExitCode = 1; Lines = $null; Expected = $false }
+)
+$classificationFailures = @()
+$classificationTempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "unity-return-classifier-$([guid]::NewGuid().ToString('N'))"
+try {
+    . $returnUnityLicenseClassifierPath
+    [void](New-Item -ItemType Directory -Path $classificationTempRoot)
+    foreach ($case in $classificationCases) {
+        $caseLog = Join-Path $classificationTempRoot "$($case.Name -replace '[^A-Za-z0-9]+', '-').log"
+        if ($null -ne $case.Lines) {
+            Set-Content -LiteralPath $caseLog -Value @($case.Lines)
+        }
+        $actual = Test-UnityLicenseReturnResourceSafe -ExitCode $case.ExitCode -LogPath $caseLog
+        if ($actual -ne $case.Expected) {
+            $classificationFailures += "$($case.Name): expected $($case.Expected), got $actual"
+        }
+    }
+} catch {
+    $classificationFailures += "classifier threw unexpectedly: $($_.Exception.Message)"
+} finally {
+    Remove-Item -LiteralPath $classificationTempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+if ($classificationFailures.Count -gt 0) {
+    Write-Host "::error file=.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1::Return classification failed: $($classificationFailures -join '; ')"
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info "Checked $($classificationCases.Count) resource cleanup classifications."
 }
 
 $unityLockUsesAppCredentials = (


### PR DESCRIPTION
## Summary
- expose conservative `resource-safe` proof from the final Unity license return helper
- pass that proof into every unconditional organization lock release
- enforce acquire → licensed work → identified cleanup → release ordering and identity for all six lock-owning jobs

## Verification
- `npm run test:unity-workflow-matrix-contract`
- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/unity-benchmarks.yml .github/workflows/unity-tests.yml`
- `npm run agent:preflight:fix`
- `npm run validate:prepush`

## Rollout
This PR is the unity-helpers consumer half of the schema-4 resource-lifecycle rollout. Merge/release should remain coordinated with the lifecycle-capable build-lock `v1` publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org-wide Unity lock release and license-seat proof; a false `resource-safe=true` could let the next job start while a seat is still held, though defaults stay conservative and rollout depends on coordinated build-lock v1 publication.
> 
> **Overview**
> Adds a **conservative `resource-safe` signal** so organization build-lock release can tell whether the runner likely still holds the Unity license seat.
> 
> The **return-unity-license** composite now defaults `resource-safe` to **false**, sets it **true** only on a zero exit code or when a new **`Test-UnityLicenseReturnResourceSafe`** helper approves a non-zero exit (exact trimmed log lines for entitlement return plus ULF skip; **rejects** kill/crash exit codes even if the log looks successful). Inline log parsing in the action is replaced by that shared classifier.
> 
> Across **release**, **unity-benchmarks**, and **unity-tests** (all lock-owning jobs), the return step gets an **id**, **5-minute timeout**, and **`continue-on-error`**. **Release organization Unity lock** runs on **success, failure, or cancelled** acquire (not only success) and passes **`resource-safe`** from the return step into **`release-build-lock@v1`**.
> 
> **`test-unity-workflow-matrix-contract.ps1`** is extended to enforce acquire → licensed work → identified cleanup → release ordering, matching holder/runner identity, the new return-step shape, **`resource-safe` wiring**, action output contracts, and classifier unit cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8bc098ea6b7b00931fa399110314f3d741b6350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->