### PR TITLE
docs: note Unity cleanup lifecycle fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unity license lock handoff after CI cleanup**: final Unity license returns now emit fail-closed cleanup proof to the organization build lock. Cleanup is bounded and non-masking, failed or cancelled acquisitions still release queued/owned lock state, and only a successful return command or exact allowlisted Unity responses permit the activation slot to enter cooldown instead of quarantine.
+
 ## [3.5.0] - 2026-07-07
 
 ### Added


### PR DESCRIPTION
## Summary
- add the required Unreleased note for the lifecycle-aware Unity cleanup fix
- document successful-command and exact allowlisted proof paths

## Verification
- npx prettier --check CHANGELOG.md
- adversarial review: zero issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only documentation with no runtime or workflow code changes in this diff.
> 
> **Overview**
> Adds an **[Unreleased] → Fixed** entry to `CHANGELOG.md` for the CI Unity license lifecycle fix (not a code change in this PR).
> 
> The note documents that final license returns must provide **fail-closed cleanup proof** to the org build lock: bounded cleanup that does not mask failures, lock release on failed/cancelled acquisitions, and **cooldown vs quarantine** for activation slots only when the return succeeds or matches an exact allowlisted Unity response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20b93b5242465d39b49ca8d5077d50299e2aee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->