### PR TITLE
Fix Unity lock cleanup evidence

### DIFF
--- a/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
+++ b/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
@@ -7,10 +7,6 @@ function Test-UnityLicenseReturnResourceSafe {
         [Parameter(Mandatory = $true)][string]$LogPath
     )
 
-    if ($ExitCode -eq 0) {
-        return $true
-    }
-
     # Process termination is never proof of cleanup, even if a partial/stale log
     # happens to contain Unity's normal success markers.
     if ($ExitCode -in @(137, 143, -1073741510, -1073740791)) {
@@ -22,17 +18,25 @@ function Test-UnityLicenseReturnResourceSafe {
             return $false
         }
 
-        $lines = [System.Collections.Generic.HashSet[string]]::new(
-            [System.StringComparer]::Ordinal
-        )
+        $entitlementReturned = $false
+        $ulfReturned = $false
         foreach ($line in (Get-Content -LiteralPath $LogPath -ErrorAction Stop)) {
-            [void]$lines.Add(([string]$line).Trim())
+            $normalized = ([string]$line).Trim()
+            if (
+                $normalized -eq 'Successfully returned the entitlement license' -or
+                $normalized -eq '[Licensing::Module] Successfully returned the entitlement license'
+            ) {
+                $entitlementReturned = $true
+            }
+            if (
+                $normalized -eq 'Serial number unavailable for ULF return' -or
+                $normalized -match '^\[Licensing::Client\] Successfully returned ULF license with serial number\s*:\s*\S+$'
+            ) {
+                $ulfReturned = $true
+            }
         }
 
-        return (
-            $lines.Contains('Successfully returned the entitlement license') -and
-            $lines.Contains('Serial number unavailable for ULF return')
-        )
+        return $entitlementReturned -and $ulfReturned
     } catch {
         return $false
     }

--- a/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
+++ b/.github/actions/return-unity-license/Classify-UnityLicenseReturn.ps1
@@ -23,14 +23,14 @@ function Test-UnityLicenseReturnResourceSafe {
         foreach ($line in (Get-Content -LiteralPath $LogPath -ErrorAction Stop)) {
             $normalized = ([string]$line).Trim()
             if (
-                $normalized -eq 'Successfully returned the entitlement license' -or
-                $normalized -eq '[Licensing::Module] Successfully returned the entitlement license'
+                $normalized -ceq 'Successfully returned the entitlement license' -or
+                $normalized -ceq '[Licensing::Module] Successfully returned the entitlement license'
             ) {
                 $entitlementReturned = $true
             }
             if (
-                $normalized -eq 'Serial number unavailable for ULF return' -or
-                $normalized -match '^\[Licensing::Client\] Successfully returned ULF license with serial number\s*:\s*\S+$'
+                $normalized -ceq 'Serial number unavailable for ULF return' -or
+                $normalized -cmatch '^\[Licensing::Client\] Successfully returned ULF license with serial number\s*:\s*\S+$'
             ) {
                 $ulfReturned = $true
             }

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -101,10 +101,16 @@ runs:
           }
 
           # Serial activation returns by account, so both credentials are required. If
-          # either is empty we cannot return -- warn (never echo the values) and
-          # exit 0 (the next run's return-at-start is the backstop).
+          # either is empty we cannot invoke the return command, but prior evidence
+          # from the licensed work still counts -- check it before falling back to
+          # the next run's backstop.
           if ([string]::IsNullOrWhiteSpace($env:UNITY_EMAIL) -or [string]::IsNullOrWhiteSpace($env:UNITY_PASSWORD)) {
-            Write-Host "::warning::UNITY_EMAIL/UNITY_PASSWORD are not both set; cannot return the Unity license here. The next run's return-at-start is the backstop."
+            if (Test-PriorReturnEvidence) {
+              Set-ConfirmedCleanupOutput
+              Write-Host "::notice::Licensed work already produced exact positive Unity return evidence."
+            } else {
+              Write-Host "::warning::UNITY_EMAIL/UNITY_PASSWORD are not both set; cannot return the Unity license here. The next run's return-at-start is the backstop."
+            }
             exit 0
           }
 

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -143,9 +143,13 @@ runs:
           $exitCode = $LASTEXITCODE
           Write-Host "::endgroup::"
 
-          if (Test-UnityLicenseReturnResourceSafe -ExitCode $exitCode -LogPath $returnLog) {
+          $currentReturnConfirmed = Test-UnityLicenseReturnResourceSafe -ExitCode $exitCode -LogPath $returnLog
+          $priorReturnConfirmed = -not $currentReturnConfirmed -and (Test-PriorReturnEvidence)
+          if ($currentReturnConfirmed -or $priorReturnConfirmed) {
             Set-ConfirmedCleanupOutput
-            if ($exitCode -ne 0) {
+            if ($priorReturnConfirmed) {
+              Write-Host "::notice::Licensed work already produced exact positive Unity return evidence; the redundant helper added no stronger proof."
+            } elseif ($exitCode -ne 0) {
               Write-Host "::notice::Unity emitted exact entitlement and ULF return evidence before exiting with code $exitCode; treating cleanup as confirmed."
             } else {
               Write-Host "::notice::Returned the Unity license seat with exact positive evidence."

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: "Path to the resolved Unity editor exe (exported to GITHUB_ENV by run-ci-tests.ps1). When empty there is nothing to return."
     required: false
   prior-return-log-path:
-    description: "Path to a non-uploaded Unity log from licensed work that may already contain exact return evidence."
+    description: "Path to a Unity return log from licensed work that may already contain exact cleanup evidence; it must not expose unredacted credentials."
     required: false
   prior-command-succeeded:
     description: "Set true only when the command that produced prior-return-log-path completed successfully."

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -9,16 +9,35 @@ inputs:
   unity-editor-path:
     description: "Path to the resolved Unity editor exe (exported to GITHUB_ENV by run-ci-tests.ps1). When empty there is nothing to return."
     required: false
+  prior-return-log-path:
+    description: "Path to a non-uploaded Unity log from licensed work that may already contain exact return evidence."
+    required: false
+  prior-command-succeeded:
+    description: "Set true only when the command that produced prior-return-log-path completed successfully."
+    required: false
+    default: "false"
 outputs:
   resource-safe:
     description: "Whether Unity confirmed that this runner no longer holds the license activation."
     value: ${{ steps.return_license.outputs.resource-safe }}
+  resource-cleanup-status:
+    description: "confirmed only when exact positive Unity return evidence was observed; otherwise unknown."
+    value: ${{ steps.return_license.outputs.resource-cleanup-status }}
+  resource-health:
+    description: "Return cleanup does not classify account health, so this remains healthy."
+    value: ${{ steps.return_license.outputs.resource-health }}
+  resource-reason:
+    description: "Stable cleanup evidence reason code."
+    value: ${{ steps.return_license.outputs.resource-reason }}
 runs:
   using: composite
   steps:
     - name: Return Unity license
       id: return_license
       shell: pwsh
+      env:
+        PRIOR_RETURN_LOG_PATH: ${{ inputs.prior-return-log-path }}
+        PRIOR_COMMAND_SUCCEEDED: ${{ inputs.prior-command-succeeded }}
       run: |
         Set-StrictMode -Version Latest
         . (Join-Path '${{ github.action_path }}' 'Classify-UnityLicenseReturn.ps1')
@@ -33,12 +52,28 @@ runs:
         # builds lack the variable; assigning it is harmless and StrictMode-safe.)
         $PSNativeCommandUseErrorActionPreference = $false
 
+        function Set-ConfirmedCleanupOutput {
+          "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "resource-cleanup-status=confirmed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "resource-reason=cleanup-confirmed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        }
+
+        function Test-PriorReturnEvidence {
+          if ($env:PRIOR_COMMAND_SUCCEEDED -ne 'true' -or [string]::IsNullOrWhiteSpace($env:PRIOR_RETURN_LOG_PATH)) {
+            return $false
+          }
+          return Test-UnityLicenseReturnResourceSafe -ExitCode 0 -LogPath $env:PRIOR_RETURN_LOG_PATH
+        }
+
         # Best-effort, never-fails seat return. Top-level try/catch + a final
-        # `exit 0` guarantee this step can never fail the build: a leaked seat is
-        # also reclaimed by the NEXT run's return-at-start even if every branch
-        # below is skipped.
+        # `exit 0` keep cleanup errors from masking the build result. Missing
+        # positive evidence remains unknown so the lock can quarantine this
+        # runner until an explicit, evidence-backed recovery.
         try {
           "resource-safe=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "resource-cleanup-status=unknown" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "resource-health=healthy" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "resource-reason=return-missing-positive-evidence" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           $editorPath = '${{ inputs.unity-editor-path }}'
           if ([string]::IsNullOrWhiteSpace($editorPath)) {
             $editorPath = $env:UNITY_EDITOR_PATH
@@ -47,11 +82,21 @@ runs:
           # Nothing to return when the editor path was never resolved (the Unity
           # run never reached the point of exporting UNITY_EDITOR_PATH).
           if ([string]::IsNullOrWhiteSpace($editorPath)) {
-            Write-Host "::notice::No Unity editor path resolved; nothing to return."
+            if (Test-PriorReturnEvidence) {
+              Set-ConfirmedCleanupOutput
+              Write-Host "::notice::Licensed work already produced exact positive Unity return evidence."
+            } else {
+              Write-Host "::notice::No Unity editor path or exact prior return evidence resolved; cleanup remains unknown."
+            }
             exit 0
           }
           if (-not (Test-Path -LiteralPath $editorPath -PathType Leaf)) {
-            Write-Host "::notice::Resolved Unity editor path does not exist; nothing to return."
+            if (Test-PriorReturnEvidence) {
+              Set-ConfirmedCleanupOutput
+              Write-Host "::notice::Licensed work already produced exact positive Unity return evidence."
+            } else {
+              Write-Host "::notice::Resolved Unity editor path does not exist and no exact prior return evidence was found; cleanup remains unknown."
+            }
             exit 0
           }
 
@@ -94,19 +139,18 @@ runs:
           $exitCode = $LASTEXITCODE
           Write-Host "::endgroup::"
 
-          if ($exitCode -ne 0) {
-            if (Test-UnityLicenseReturnResourceSafe -ExitCode $exitCode -LogPath $returnLog) {
-              "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-              Write-Host "::notice::Unity returned the entitlement license, then exited with code $exitCode while skipping legacy ULF return; treating the seat return as successful."
+          if (Test-UnityLicenseReturnResourceSafe -ExitCode $exitCode -LogPath $returnLog) {
+            Set-ConfirmedCleanupOutput
+            if ($exitCode -ne 0) {
+              Write-Host "::notice::Unity emitted exact entitlement and ULF return evidence before exiting with code $exitCode; treating cleanup as confirmed."
             } else {
-              Write-Host "::warning::Unity license return exited with code $exitCode; the next run's return-at-start is the backstop for the leaked seat."
+              Write-Host "::notice::Returned the Unity license seat with exact positive evidence."
             }
           } else {
-            "resource-safe=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            Write-Host "::notice::Returned the Unity license seat."
+            Write-Host "::warning::Unity license return exited with code $exitCode without exact positive evidence; cleanup remains unknown."
           }
         } catch {
-          Write-Host "::warning::Unity license return step hit an unexpected error: $($_.Exception.Message). The next run's return-at-start is the backstop."
+          Write-Host "::warning::Unity license return step hit an unexpected error: $($_.Exception.Message). Cleanup remains unknown and lock release will quarantine this runner."
         }
         # Defense-in-depth: this step must never fail the build.
         exit 0

--- a/.github/actions/return-unity-license/action.yml
+++ b/.github/actions/return-unity-license/action.yml
@@ -100,11 +100,15 @@ runs:
             exit 0
           }
 
-          # Serial activation returns by account, so both credentials are required. If
-          # either is empty we cannot return -- warn (never echo the values) and
-          # exit 0 (the next run's return-at-start is the backstop).
+          # Serial activation returns by account, so both credentials are required
+          # unless the licensed command already proved cleanup. Never echo them.
           if ([string]::IsNullOrWhiteSpace($env:UNITY_EMAIL) -or [string]::IsNullOrWhiteSpace($env:UNITY_PASSWORD)) {
-            Write-Host "::warning::UNITY_EMAIL/UNITY_PASSWORD are not both set; cannot return the Unity license here. The next run's return-at-start is the backstop."
+            if (Test-PriorReturnEvidence) {
+              Set-ConfirmedCleanupOutput
+              Write-Host "::notice::Licensed work already produced exact positive Unity return evidence."
+            } else {
+              Write-Host "::warning::UNITY_EMAIL/UNITY_PASSWORD are not both set and no exact prior return evidence was found; cleanup remains unknown."
+            }
             exit 0
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -357,6 +357,7 @@ jobs:
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Export Unity package
+        id: export_unitypackage
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -377,18 +378,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: .artifacts/unity/unitypackage-project/unitypackage-output/unity.log
+          prior-command-succeeded: ${{ steps.export_unitypackage.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -398,10 +398,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
         with:
-          prior-return-log-path: >-
-            ${{ matrix.test-mode == 'editmode' &&
-            format('.artifacts/unity/benchmarks-random/{0}/unity.log', matrix.unity-version) ||
-            format('.artifacts/unity/benchmarks/{0}-{1}/unity.log', matrix.unity-version, matrix.test-mode) }}
+          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
           prior-command-succeeded: >-
             ${{ (matrix.test-mode == 'editmode' &&
             steps.run_random_thorough.outcome == 'success') ||

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -398,8 +398,14 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
         with:
-          prior-return-log-path: ${{ matrix.test-mode == 'editmode' && format('.artifacts/unity/benchmarks-random/{0}/unity.log', matrix.unity-version) || format('.artifacts/unity/benchmarks/{0}-{1}/unity.log', matrix.unity-version, matrix.test-mode) }}
-          prior-command-succeeded: ${{ (matrix.test-mode == 'editmode' && steps.run_random_thorough.outcome == 'success') || (matrix.test-mode != 'editmode' && steps.run_tests.outcome == 'success') }}
+          prior-return-log-path: >-
+            ${{ matrix.test-mode == 'editmode' &&
+            format('.artifacts/unity/benchmarks-random/{0}/unity.log', matrix.unity-version) ||
+            format('.artifacts/unity/benchmarks/{0}-{1}/unity.log', matrix.unity-version, matrix.test-mode) }}
+          prior-command-succeeded: >-
+            ${{ (matrix.test-mode == 'editmode' &&
+            steps.run_random_thorough.outcome == 'success') ||
+            (matrix.test-mode != 'editmode' && steps.run_tests.outcome == 'success') }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -325,7 +325,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -397,18 +397,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: ${{ matrix.test-mode == 'editmode' && format('.artifacts/unity/benchmarks-random/{0}/unity.log', matrix.unity-version) || format('.artifacts/unity/benchmarks/{0}-{1}/unity.log', matrix.unity-version, matrix.test-mode) }}
+          prior-command-succeeded: ${{ (matrix.test-mode == 'editmode' && steps.run_random_thorough.outcome == 'success') || (matrix.test-mode != 'editmode' && steps.run_tests.outcome == 'success') }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -477,7 +477,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -543,18 +543,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/unity.log
+          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -814,7 +819,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -880,18 +885,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/unity.log
+          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -1136,7 +1146,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1197,18 +1207,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded/unity.log
+          prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
@@ -1287,7 +1302,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1298,6 +1313,7 @@ jobs:
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}
 
       - name: Export Unity package smoke artifact
+        id: export_unitypackage
         timeout-minutes: 120
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
@@ -1320,18 +1336,23 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
+        with:
+          prior-return-log-path: .artifacts/unity/unitypackage-smoke-project/unitypackage-output/unity.log
+          prior-command-succeeded: ${{ steps.export_unitypackage.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
           runner-id: ${{ runner.name }}
-          resource-safe: ${{ steps.return_unity_license.outputs.resource-safe }}
+          resource-cleanup-status: ${{ steps.return_unity_license.outputs.resource-cleanup-status }}
+          resource-health: ${{ steps.return_unity_license.outputs.resource-health }}
+          resource-reason: ${{ steps.return_unity_license.outputs.resource-reason }}
         env:
           BUILD_LOCK_APP_ID: ${{ secrets.BUILD_LOCK_APP_ID }}
           BUILD_LOCK_APP_PRIVATE_KEY: ${{ secrets.BUILD_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -544,7 +544,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
         with:
-          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/unity.log
+          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
           prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -886,7 +886,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
         with:
-          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}/unity.log
+          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
           prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -1208,7 +1208,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/return-unity-license
         with:
-          prior-return-log-path: .artifacts/unity/${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded/unity.log
+          prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log
           prior-command-succeeded: ${{ steps.run_tests.outcome == 'success' }}
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2139,7 +2139,7 @@ $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?ms)function Test-PriorReturnEvidence \{.*?PRIOR_COMMAND_SUCCEEDED.*?Test-UnityLicenseReturnResourceSafe -ExitCode 0 -LogPath \$env:PRIOR_RETURN_LOG_PATH.*?\}' -and
     $priorReturnEvidenceGuards.Count -eq 3 -and
     $returnUnityLicenseActionContent -match '(?ms)if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNITY_EMAIL\).*?\) \{\s+if \(Test-PriorReturnEvidence\) \{\s+Set-ConfirmedCleanupOutput' -and
-    $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s+Set-ConfirmedCleanupOutput'
+    $returnUnityLicenseActionContent -match '(?ms)\$currentReturnConfirmed = Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\s+\$priorReturnConfirmed = -not \$currentReturnConfirmed -and \(Test-PriorReturnEvidence\)\s+if \(\$currentReturnConfirmed -or \$priorReturnConfirmed\) \{\s+Set-ConfirmedCleanupOutput'
 )
 if (-not $returnActionResourceProofContract) {
     Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default cleanup to unknown and confirm it only from exact current or prior return evidence.'

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2104,7 +2104,7 @@ $runnerTempReturnLogInput = [regex]::Escape('prior-return-log-path: ${{ runner.t
 $testRunnerTempReturnLogs = [regex]::Matches($workflowContent, $runnerTempReturnLogInput).Count
 $benchmarkRunnerTempReturnLogs = [regex]::Matches(($benchmarksWorkflowLines -join "`n"), $runnerTempReturnLogInput).Count
 if ($testRunnerTempReturnLogs -ne 3 -or $benchmarkRunnerTempReturnLogs -ne 1) {
-    Write-Host "::error file=.github/workflows/unity-tests.yml::run-ci-tests.ps1 cleanup proof must come from its non-uploaded runner-temp return log (tests=$testRunnerTempReturnLogs, benchmarks=$benchmarkRunnerTempReturnLogs)."
+    Write-Host "::error file=scripts/tests/test-unity-workflow-matrix-contract.ps1::run-ci-tests.ps1 cleanup proof must come from its non-uploaded runner-temp return log (tests=$testRunnerTempReturnLogs, benchmarks=$benchmarkRunnerTempReturnLogs)."
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked run-ci-tests workflows classify the runner-temp Unity return log.'

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -8,6 +8,7 @@ param([switch]$VerboseOutput)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$buildLockActionCommit = 'cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af'
 
 function Write-Info($msg) {
     if ($VerboseOutput) { Write-Host "[test-unity-workflow-matrix-contract] $msg" -ForegroundColor Cyan }
@@ -257,8 +258,8 @@ function Test-UnityLockCleanupIsGated {
         [Parameter(Mandatory = $true)][hashtable]$LicensedWorkStepNames
     )
 
-    $acquireUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
-    $releaseUses = 'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
+    $acquireUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@$buildLockActionCommit"
+    $releaseUses = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@$buildLockActionCommit"
     $returnUses = './.github/actions/return-unity-license'
     $requiredCleanupGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
     $requiredReleaseGate = 'if: ${{ always() && (steps.unity_lock.outcome == ''success'' || steps.unity_lock.outcome == ''failure'' || steps.unity_lock.outcome == ''cancelled'') }}'
@@ -289,6 +290,7 @@ function Test-UnityLockCleanupIsGated {
         }
         $acquireStep = [regex]::Match($jobText, '(?ms)^\s+- name: Acquire organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
         $releaseStep = [regex]::Match($jobText, '(?ms)^\s+- name: Release organization Unity lock\s*$.*?(?=^\s+- name:|\z)')
+        $returnStep = [regex]::Match($jobText, '(?ms)^\s+- name: Return Unity license\s*$.*?(?=^\s+- name:|\z)')
         $acquireHolder = [regex]::Match($acquireStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
         $releaseHolder = [regex]::Match($releaseStep.Value, '(?m)^\s+holder-id-suffix:\s*(?<value>[^\r\n]+)')
         $acquireRunner = [regex]::Match($acquireStep.Value, '(?m)^\s+runner-id:\s*(?<value>[^\r\n]+)')
@@ -299,6 +301,12 @@ function Test-UnityLockCleanupIsGated {
         }
         if ($jobText -notmatch $returnPattern) {
             $failures += "$($job.Key): return-unity-license must be identified, success-gated, bounded to five minutes, and non-masking"
+        }
+        if (
+            $returnStep.Value -notmatch '(?m)^\s+prior-return-log-path:\s+\S.*$' -or
+            $returnStep.Value -notmatch '(?m)^\s+prior-command-succeeded:\s+\$\{\{\s+.+\s+\}\}\s*$'
+        ) {
+            $failures += "$($job.Key): return-unity-license must classify the licensed command's log and successful outcome"
         }
         if ($jobText -notmatch $releasePattern) {
             $failures += "$($job.Key): release-build-lock must run after every non-skipped acquire outcome"
@@ -318,8 +326,12 @@ function Test-UnityLockCleanupIsGated {
         if (-not $acquireRunner.Success -or -not $releaseRunner.Success -or $acquireRunner.Groups['value'].Value.Trim() -ne $releaseRunner.Groups['value'].Value.Trim()) {
             $failures += "$($job.Key): acquire and release must use the same runner-id"
         }
-        if ($releaseStep.Value -notmatch '(?m)^\s+resource-safe:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-safe \}\}\s*$') {
-            $failures += "$($job.Key): release must pass the identified cleanup resource-safe output"
+        if (
+            $releaseStep.Value -notmatch '(?m)^\s+resource-cleanup-status:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-cleanup-status \}\}\s*$' -or
+            $releaseStep.Value -notmatch '(?m)^\s+resource-health:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-health \}\}\s*$' -or
+            $releaseStep.Value -notmatch '(?m)^\s+resource-reason:\s+\$\{\{ steps\.return_unity_license\.outputs\.resource-reason \}\}\s*$'
+        ) {
+            $failures += "$($job.Key): release must pass the identified cleanup status, health, and reason outputs"
         }
     }
 
@@ -354,9 +366,9 @@ function Test-UnityLockAppConfiguration {
         $isAcquireStep = $stepText.Contains('Acquire organization Unity lock')
         $stepKind = if ($isAcquireStep) { 'Acquire' } else { 'Release' }
         $expectedAction = if ($isAcquireStep) {
-            'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@v1'
+            "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@$buildLockActionCommit"
         } else {
-            'Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@v1'
+            "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@$buildLockActionCommit"
         }
 
         $exactActionPattern = '(?m)^\s+uses:\s+' + [regex]::Escape($expectedAction) + '[ \t]*\r?$'
@@ -2098,23 +2110,40 @@ $resourceSafeTrueAssignments = [regex]::Matches(
 )
 $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-safe:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-safe \}\}\s*$' -and
+    $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-cleanup-status:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-cleanup-status \}\}\s*$' -and
+    $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-health:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-health \}\}\s*$' -and
+    $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-reason:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-reason \}\}\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_license\s*\r?\n' -and
     $resourceSafeFalseAssignments.Count -eq 1 -and
-    $resourceSafeTrueAssignments.Count -eq 2 -and
+    $resourceSafeTrueAssignments.Count -eq 1 -and
     $returnUnityLicenseActionContent -match [regex]::Escape('. (Join-Path ''${{ github.action_path }}'' ''Classify-UnityLicenseReturn.ps1'')') -and
     $returnUnityLicenseActionContent -match '(?ms)try \{\s*"resource-safe=false"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
-    $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append' -and
-    $returnUnityLicenseActionContent -match '(?ms)\} else \{\s*"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s+Write-Host "::notice::Returned the Unity license seat\."'
+    $returnUnityLicenseActionContent -match '(?m)^\s+"resource-cleanup-status=unknown"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$' -and
+    $returnUnityLicenseActionContent -match '(?m)^\s+"resource-health=healthy"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$' -and
+    $returnUnityLicenseActionContent -match '(?m)^\s+"resource-reason=return-missing-positive-evidence"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$' -and
+    $returnUnityLicenseActionContent -match '(?ms)function Set-ConfirmedCleanupOutput \{.*?"resource-cleanup-status=confirmed".*?"resource-reason=cleanup-confirmed".*?\}' -and
+    $returnUnityLicenseActionContent -match '(?ms)function Test-PriorReturnEvidence \{.*?PRIOR_COMMAND_SUCCEEDED.*?Test-UnityLicenseReturnResourceSafe -ExitCode 0 -LogPath \$env:PRIOR_RETURN_LOG_PATH.*?\}' -and
+    $returnUnityLicenseActionContent -match '(?ms)if \(Test-PriorReturnEvidence\) \{\s+Set-ConfirmedCleanupOutput' -and
+    $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s+Set-ConfirmedCleanupOutput'
 )
 if (-not $returnActionResourceProofContract) {
-    Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default resource-safe to false and set it true only for exit code zero or the strict classifier allowlist.'
+    Write-Host '::error file=.github/actions/return-unity-license/action.yml::Return action must default cleanup to unknown and confirm it only from exact current or prior return evidence.'
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info 'Checked return action emits conservative, non-masking cleanup proof.'
 }
 
 $classificationCases = @(
-    @{ Name = 'zero exit'; ExitCode = 0; Lines = @(); Expected = $true }
+    @{ Name = 'zero exit without positive evidence'; ExitCode = 0; Lines = @(); Expected = $false }
+    @{
+        Name = 'production entitlement and ULF return markers'
+        ExitCode = 0
+        Lines = @(
+            '[Licensing::Module] Successfully returned the entitlement license'
+            '[Licensing::Client] Successfully returned ULF license with serial number : <redacted>'
+        )
+        Expected = $true
+    }
     @{ Name = 'dual exact normalized markers'; ExitCode = 1; Lines = @('  Successfully returned the entitlement license  ', "`tSerial number unavailable for ULF return"); Expected = $true }
     @{ Name = 'generic success'; ExitCode = 1; Lines = @('License return succeeded'); Expected = $false }
     @{ Name = 'one marker'; ExitCode = 1; Lines = @('Successfully returned the entitlement license'); Expected = $false }

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -304,7 +304,7 @@ function Test-UnityLockCleanupIsGated {
         }
         if (
             $returnStep.Value -notmatch '(?m)^\s+prior-return-log-path:\s+\S.*$' -or
-            $returnStep.Value -notmatch '(?m)^\s+prior-command-succeeded:\s+\$\{\{\s+.+\s+\}\}\s*$'
+            $returnStep.Value -notmatch '(?ms)^\s+prior-command-succeeded:\s+(?:>-\s*\r?\n\s*)?\$\{\{\s+.+?\s+\}\}\s*(?=^\s+env:)'
         ) {
             $failures += "$($job.Key): return-unity-license must classify the licensed command's log and successful outcome"
         }

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2108,6 +2108,10 @@ $resourceSafeTrueAssignments = [regex]::Matches(
     $returnUnityLicenseActionContent,
     '(?m)^\s+"resource-safe=true"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$'
 )
+$priorReturnEvidenceGuards = [regex]::Matches(
+    $returnUnityLicenseActionContent,
+    '(?m)^\s+if \(Test-PriorReturnEvidence\) \{\s*$'
+)
 $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-safe:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-safe \}\}\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)^outputs:\s*$.*?^\s+resource-cleanup-status:\s*$.*?^\s+value:\s+\$\{\{ steps\.return_license\.outputs\.resource-cleanup-status \}\}\s*$' -and
@@ -2123,7 +2127,8 @@ $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?m)^\s+"resource-reason=return-missing-positive-evidence"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)function Set-ConfirmedCleanupOutput \{.*?"resource-cleanup-status=confirmed".*?"resource-reason=cleanup-confirmed".*?\}' -and
     $returnUnityLicenseActionContent -match '(?ms)function Test-PriorReturnEvidence \{.*?PRIOR_COMMAND_SUCCEEDED.*?Test-UnityLicenseReturnResourceSafe -ExitCode 0 -LogPath \$env:PRIOR_RETURN_LOG_PATH.*?\}' -and
-    $returnUnityLicenseActionContent -match '(?ms)if \(Test-PriorReturnEvidence\) \{\s+Set-ConfirmedCleanupOutput' -and
+    $priorReturnEvidenceGuards.Count -eq 3 -and
+    $returnUnityLicenseActionContent -match '(?ms)if \(\[string\]::IsNullOrWhiteSpace\(\$env:UNITY_EMAIL\).*?\) \{\s+if \(Test-PriorReturnEvidence\) \{\s+Set-ConfirmedCleanupOutput' -and
     $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s+Set-ConfirmedCleanupOutput'
 )
 if (-not $returnActionResourceProofContract) {

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2123,7 +2123,8 @@ $returnActionResourceProofContract = (
     $returnUnityLicenseActionContent -match '(?m)^\s+"resource-reason=return-missing-positive-evidence"\s+\|\s+Out-File\s+-FilePath\s+\$env:GITHUB_OUTPUT\s+-Append\s*$' -and
     $returnUnityLicenseActionContent -match '(?ms)function Set-ConfirmedCleanupOutput \{.*?"resource-cleanup-status=confirmed".*?"resource-reason=cleanup-confirmed".*?\}' -and
     $returnUnityLicenseActionContent -match '(?ms)function Test-PriorReturnEvidence \{.*?PRIOR_COMMAND_SUCCEEDED.*?Test-UnityLicenseReturnResourceSafe -ExitCode 0 -LogPath \$env:PRIOR_RETURN_LOG_PATH.*?\}' -and
-    $returnUnityLicenseActionContent -match '(?ms)if \(Test-PriorReturnEvidence\) \{\s+Set-ConfirmedCleanupOutput' -and
+    ([regex]::Matches($returnUnityLicenseActionContent, '(?m)^\s+if \(Test-PriorReturnEvidence\)')).Count -eq 3 -and
+    $returnUnityLicenseActionContent -match '(?ms)IsNullOrWhiteSpace\(\$env:UNITY_EMAIL\).*?if \(Test-PriorReturnEvidence\)' -and
     $returnUnityLicenseActionContent -match '(?ms)if \(Test-UnityLicenseReturnResourceSafe -ExitCode \$exitCode -LogPath \$returnLog\) \{\s+Set-ConfirmedCleanupOutput'
 )
 if (-not $returnActionResourceProofContract) {

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -2145,6 +2145,7 @@ $classificationCases = @(
         Expected = $true
     }
     @{ Name = 'dual exact normalized markers'; ExitCode = 1; Lines = @('  Successfully returned the entitlement license  ', "`tSerial number unavailable for ULF return"); Expected = $true }
+    @{ Name = 'case-altered markers'; ExitCode = 0; Lines = @('Successfully Returned the entitlement license', 'Serial Number unavailable for ULF return'); Expected = $false }
     @{ Name = 'generic success'; ExitCode = 1; Lines = @('License return succeeded'); Expected = $false }
     @{ Name = 'one marker'; ExitCode = 1; Lines = @('Successfully returned the entitlement license'); Expected = $false }
     @{ Name = 'negated marker substrings'; ExitCode = 1; Lines = @('Not Successfully returned the entitlement license', 'Not Serial number unavailable for ULF return'); Expected = $false }

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -302,10 +302,10 @@ function Test-UnityLockCleanupIsGated {
         if ($jobText -notmatch $returnPattern) {
             $failures += "$($job.Key): return-unity-license must be identified, success-gated, bounded to five minutes, and non-masking"
         }
-        if (
-            $returnStep.Value -notmatch '(?m)^\s+prior-return-log-path:\s+\S.*$' -or
-            $returnStep.Value -notmatch '(?ms)^\s+prior-command-succeeded:\s+(?:>-\s*\r?\n\s*)?\$\{\{\s+.+?\s+\}\}\s*(?=^\s+env:)'
-        ) {
+        if ($returnStep.Success -and (
+                $returnStep.Value -notmatch '(?m)^\s+prior-return-log-path:\s+\S.*$' -or
+                $returnStep.Value -notmatch '(?ms)^\s+prior-command-succeeded:\s+(?:>-\s*\r?\n\s*)?\$\{\{\s+.+?\s+\}\}\s*(?=^\s+env:)'
+            )) {
             $failures += "$($job.Key): return-unity-license must classify the licensed command's log and successful outcome"
         }
         if ($jobText -notmatch $releasePattern) {
@@ -2098,6 +2098,16 @@ if (-not $unityLockCleanupIsGated) {
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info "Checked Unity lock cleanup runs only after acquisition and before release."
+}
+
+$runnerTempReturnLogInput = [regex]::Escape('prior-return-log-path: ${{ runner.temp }}/unity-return-${{ matrix.unity-version }}-${{ matrix.test-mode }}.log')
+$testRunnerTempReturnLogs = [regex]::Matches($workflowContent, $runnerTempReturnLogInput).Count
+$benchmarkRunnerTempReturnLogs = [regex]::Matches(($benchmarksWorkflowLines -join "`n"), $runnerTempReturnLogInput).Count
+if ($testRunnerTempReturnLogs -ne 3 -or $benchmarkRunnerTempReturnLogs -ne 1) {
+    Write-Host "::error file=.github/workflows/unity-tests.yml::run-ci-tests.ps1 cleanup proof must come from its non-uploaded runner-temp return log (tests=$testRunnerTempReturnLogs, benchmarks=$benchmarkRunnerTempReturnLogs)."
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info 'Checked run-ci-tests workflows classify the runner-temp Unity return log.'
 }
 
 $resourceSafeFalseAssignments = [regex]::Matches(


### PR DESCRIPTION
## What changed

- require exact entitlement and ULF return evidence before cleanup is classified as confirmed
- reuse the licensed Unity command's log when the follow-up return helper cannot resolve an editor path
- emit schema-5-compatible cleanup status, health, and stable reason outputs
- pin every build-lock acquire/release action to the immutable v1.6.0 commit `cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af`
- add contract fixtures for positive, missing, partial, negated, and terminated cleanup evidence

## Why

Run `29239021138` returned the Unity entitlement and ULF successfully, but the follow-up helper lacked `UNITY_EDITOR_PATH` and reported `resource-safe=false`. Schema 4 correctly quarantined that runner, reducing effective capacity to zero. The helper must consume exact positive evidence from the command that actually performed cleanup without treating exit zero or generic messages as proof.

## Impact

Successful cleanup remains fail-closed unless both exact Unity return markers are present. Missing, truncated, timed-out, or terminated evidence remains unknown and produces runner-local quarantine.

The affected Unity workflows remain disabled until this PR is reviewed, merged, and canaried.

## Validation

- classifier/workflow contract suite passes for the changed behavior
- changed-file formatting, spelling, EOL, and meta preflight passes
- actionlint and diff checks pass
- Unity compile/tests skipped because no local Unity license is configured
- `test:gitignore-docs` has five unrelated failures reproduced unchanged on pristine `origin/main`

Tracking: Ambiguous-Interactive/ambiguous-organization-build-lock#30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org-wide Unity lock release and runner quarantine behavior; incorrect evidence rules could quarantine runners or accept unsafe releases, but scope is CI licensing/locking with expanded contract tests.
> 
> **Overview**
> Tightens **Unity license seat cleanup** so the org build lock only treats a runner as safe when logs show **both** exact entitlement and ULF return markers—**exit code 0 alone no longer counts**, and case-altered or partial lines are rejected. Termination exit codes still never count as proof.
> 
> The **return-unity-license** composite action now defaults to **unknown** cleanup (`resource-cleanup-status`, `resource-health`, `resource-reason`) and confirms cleanup only via a single `Set-ConfirmedCleanupOutput` path. It accepts **`prior-return-log-path`** and **`prior-command-succeeded`** so successful licensed work (e.g. `run-ci-tests.ps1`’s runner-temp return log or export `unity.log`) can confirm cleanup when the follow-up `-returnlicense` helper has no editor path or credentials.
> 
> **release**, **unity-tests**, **unity-benchmarks**, and related jobs wire those prior-log inputs, add step IDs on export steps where needed, and pass the new cleanup outputs into **release-build-lock** (replacing reliance on `resource-safe` alone). Build-lock acquire/release actions are **pinned to commit** `cfdcf6e67d7720824d21c37aa6a8b9e70dbdd2af`.
> 
> **`test-unity-workflow-matrix-contract.ps1`** enforces the new wiring, classifier fixtures, and return-action output contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03476d3b8cb3605ab92529532a4e8cbad41628b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->