### PR TITLE
Restore Unity validation for same-repository PRs

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -50,6 +50,13 @@ concurrency:
 jobs:
   matrix-config:
     name: Resolve Unity test matrix
+    if: >-
+      ${{
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+        (github.event_name != 'push' || github.ref_protected)
+      }}
+    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -145,7 +152,11 @@ jobs:
 
       - name: Check for required licensed workflow secrets
         id: check-secrets
-        if: ${{ github.event_name != 'pull_request' }}
+        if: >-
+          ${{
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          }}
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -179,9 +190,11 @@ jobs:
     # Only when we can prove the inventory is wrong do we fail hard.
     if: >-
       ${{
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected)
       }}
+    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -285,10 +298,12 @@ jobs:
       - runner-preflight
     if: >-
       ${{
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
+    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -630,11 +645,13 @@ jobs:
       - unity-tests
     if: >-
       ${{
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.has-required-secrets == 'true' &&
         needs.matrix-config.outputs.matrix-include-standalone != '[]'
       }}
+    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -978,7 +995,8 @@ jobs:
     if: >-
       ${{
         always() &&
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.result == 'success' &&
         needs.runner-preflight.result == 'success' &&
@@ -987,6 +1005,7 @@ jobs:
           needs.unity-tests-standalone.result == 'skipped') &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
+    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -1265,7 +1284,8 @@ jobs:
     if: >-
       ${{
         always() &&
-        github.event_name != 'pull_request' &&
+        (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.result == 'success' &&
         needs.runner-preflight.result == 'success' &&
@@ -1275,6 +1295,7 @@ jobs:
         needs.unity-tests-single-threaded.result == 'success' &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
+    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:

--- a/scripts/tests/test-portable-cleanup-classifier.js
+++ b/scripts/tests/test-portable-cleanup-classifier.js
@@ -60,13 +60,15 @@ for (const job of [
   assert.notEqual(start, -1, `missing job ${job}`);
   const next = workflow.slice(start + 2).search(/^  [a-z0-9-]+:/mu);
   const block = workflow.slice(start, next === -1 ? undefined : start + 2 + next);
+  const jobIf = block.match(/^    if:\s*>-\s*\r?\n(?<expression>(?:^      .*\r?\n?)+)/mu);
+  assert.ok(jobIf, `${job} must have a multiline job-level if expression`);
   assert.match(
-    block,
+    jobIf.groups.expression,
     trustedPullRequestGuard,
     `${job} must admit same-repository PRs and reject forks`
   );
   assert.doesNotMatch(
-    block,
+    jobIf.groups.expression,
     /github\.event_name\s*!=\s*'pull_request'\s*&&/u,
     `${job} must not reject every pull request`
   );

--- a/scripts/tests/test-portable-cleanup-classifier.js
+++ b/scripts/tests/test-portable-cleanup-classifier.js
@@ -46,7 +46,10 @@ assert.doesNotMatch(action, /shell:\s*pwsh/u);
 assert.match(action, /resource-cleanup-status/u);
 
 const workflow = fs.readFileSync(path.join(root, ".github/workflows/unity-tests.yml"), "utf8");
+const trustedPullRequestGuard =
+  /github\.event_name\s*!=\s*'pull_request'\s*\|\|\s*github\.event\.pull_request\.head\.repo\.full_name\s*==\s*github\.repository/u;
 for (const job of [
+  "matrix-config",
   "runner-preflight",
   "unity-tests",
   "unity-tests-standalone",
@@ -59,13 +62,22 @@ for (const job of [
   const block = workflow.slice(start, next === -1 ? undefined : start + 2 + next);
   assert.match(
     block,
-    /github\.event_name != 'pull_request'/u,
-    `${job} must not run licensed PR code`
+    trustedPullRequestGuard,
+    `${job} must admit same-repository PRs and reject forks`
   );
+  assert.doesNotMatch(
+    block,
+    /github\.event_name\s*!=\s*'pull_request'\s*&&/u,
+    `${job} must not reject every pull request`
+  );
+  assert.match(block, /^    environment:\s*unity-license\s*$/mu, `${job} must use unity-license`);
 }
 assert.match(
   workflow,
-  /- name: Check for required licensed workflow secrets[\s\S]*?if: \$\{\{ github\.event_name != 'pull_request' \}\}/u
+  new RegExp(
+    String.raw`- name: Check for required licensed workflow secrets[\s\S]*?if:\s*(?:>-\s*)?\$\{\{\s*${trustedPullRequestGuard.source}\s*\}\}`,
+    "u"
+  )
 );
 
 process.stdout.write("Portable Unity cleanup classifier tests passed.\n");


### PR DESCRIPTION
## Summary
- allow same-repository pull requests into every Unity validation tier while keeping fork PRs unlicensed
- require the protected `unity-license` environment on the secrets gate, runner preflight, and every credential-bearing Unity job
- add red/green policy coverage for PR admission, fork exclusion, and protected-environment use

## Environment cutover
- created `unity-license` with required reviewer `wallstop`
- all branches are eligible; the workflow's same-repository guard is evaluated before environment entry

## Verification
- `npm run test:portable-cleanup-classifier`
- `actionlint -shellcheck '' -pyflakes '' .github/workflows/unity-tests.yml`
- `npm run lint:workflow-run-expression-length`
- Prettier and diff checks
- deep Unity matrix contract reached the repository's pre-existing machine-health-dependent bootstrap assertion; all workflow/lock contracts before and after that assertion passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Licensed secrets and self-hosted runners can run on same-repo PRs; fork exclusion and the protected environment are the main security controls, now enforced by workflow expressions and tests.
> 
> **Overview**
> **Same-repository pull requests** can run the full Unity CI matrix again; **fork PRs** stay blocked from jobs that use Unity and build-lock secrets.
> 
> Job `if` conditions no longer use a blanket `github.event_name != 'pull_request'`. They use a **trusted PR guard**: non-PR events (with existing protected-branch rules on push) **or** PRs whose head repo matches `github.repository`. That guard applies to `matrix-config`, `runner-preflight`, all Unity test tiers, and `unitypackage-smoke`. The **Check for required licensed workflow secrets** step uses the same guard so fork PRs do not probe licensed secrets.
> 
> Every credential-bearing job now declares **`environment: unity-license`**, including `matrix-config` (new job-level `if` there as well).
> 
> `scripts/tests/test-portable-cleanup-classifier.js` encodes this contract: each licensed job must expose a multiline `if` with the trusted guard, must not reject all PRs, must set `unity-license`, and the secrets check step must match the guard pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6e76775a9c7dcc8e1e1fa0a4097feeab5e0eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->