### PR TITLE
Fix Unity CLI install path timeout recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unity CLI install-path probes hanging under service accounts**: CI-managed editor provisioning now preserves an exact install-path confirmation captured before the watchdog stops a lingering Unity CLI process tree, so NetworkService runners can continue provisioning instead of discarding the confirmed path as a failed probe.
+
 ## [3.5.1] - 2026-07-12
 
 ### Fixed

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -127,6 +127,9 @@ function Import-EnsureEditorWatchdogFunctions {
         'ConvertTo-ProcessArgumentLine',
         'Get-EnsureEditorRetryDelaySeconds',
         'Get-EnsureEditorInstallTimeoutSeconds',
+        'Get-EnsureEditorProbeTimeoutSeconds',
+        'Get-EffectiveUnityCliTimeoutSeconds',
+        'Get-RemainingUnityProvisioningBudgetSeconds',
         'Get-EnsureEditorProgressStallSeconds',
         'Get-EnsureEditorProgressNoticeIntervalSeconds',
         'Get-EnsureEditorQuarantineMoveRetryAttempts',
@@ -140,7 +143,10 @@ function Import-EnsureEditorWatchdogFunctions {
         'Get-CollapsedCliOutputTail',
         'Get-CliProgressTriple',
         'Get-LastCliProgressMessage',
+        'Write-CiNotice',
         'Invoke-UnityCliCaptureWithTimeout',
+        'Invoke-UnityCliSafe',
+        'Get-UnityCliOutput',
         'Move-UnityInstallDirectoryToQuarantine',
         'Get-UnityProvisioningProfile'
     )) {
@@ -1713,6 +1719,76 @@ if ($ensureEditorWatchdogImported) {
         } else {
             Remove-Variable -Name UnityProvisioningProfile -Scope Script -ErrorAction SilentlyContinue
         }
+    }
+
+    $originalUnityCliCapture = ${function:Invoke-UnityCliCaptureWithTimeout}
+    $oldProvisioningDeadlineVariable = Get-Variable -Name ProvisioningDeadlineUtc -Scope Script -ErrorAction SilentlyContinue
+    $oldProvisioningDeadline = if ($oldProvisioningDeadlineVariable) { $oldProvisioningDeadlineVariable.Value } else { $null }
+    try {
+        $script:ProvisioningDeadlineUtc = [DateTime]::MaxValue
+        $script:unityCliCaptureResult = @{
+            Success           = $false
+            ExitCode          = 124
+            Output            = @('D:\actions-runner\_work\_tool\qora-unity-editors')
+            StallKilled       = $false
+            TimedOutWallClock = $true
+        }
+        function script:Invoke-UnityCliCaptureWithTimeout {
+            param(
+                [string[]]$Arguments,
+                [int]$TimeoutSeconds,
+                [string]$TimeoutKnob,
+                [switch]$TimeoutAsWarning
+            )
+            return $script:unityCliCaptureResult
+        }
+
+        $discardedTimedOutOutput = Get-UnityCliOutput -Arguments @('install-path')
+        $acceptedTimedOutOutput = @(Get-UnityCliOutput -Arguments @('install-path') -AcceptCapturedOutputOnTimeout)
+        $acceptedTimedOutSetter = Invoke-UnityCliSafe `
+            -Arguments @('install-path', '-s', 'D:\actions-runner\_work\_tool\qora-unity-editors') `
+            -AcceptCapturedOutputPattern '^D:\\actions-runner\\_work\\_tool\\qora-unity-editors$'
+        $script:unityCliCaptureResult.Output = @('D:\unexpected-root')
+        $rejectedMismatchedSetter = Invoke-UnityCliSafe `
+            -Arguments @('install-path', '-s', 'D:\actions-runner\_work\_tool\qora-unity-editors') `
+            -AcceptCapturedOutputPattern '^D:\\actions-runner\\_work\\_tool\\qora-unity-editors$'
+        $script:unityCliCaptureResult.Output = @('D:\actions-runner\_work\_tool\qora-unity-editors')
+        $script:unityCliCaptureResult.TimedOutWallClock = $false
+        $rejectedNativeExitSetter = Invoke-UnityCliSafe `
+            -Arguments @('install-path', '-s', 'D:\actions-runner\_work\_tool\qora-unity-editors') `
+            -AcceptCapturedOutputPattern '^D:\\actions-runner\\_work\\_tool\\qora-unity-editors$'
+        if (
+            $null -ne $discardedTimedOutOutput -or
+            $acceptedTimedOutOutput.Count -ne 1 -or
+            $acceptedTimedOutOutput[0] -ne 'D:\actions-runner\_work\_tool\qora-unity-editors' -or
+            -not $acceptedTimedOutSetter -or
+            $rejectedMismatchedSetter -or
+            $rejectedNativeExitSetter
+        ) {
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Install-path probes must accept exact positive output captured before a wrapper timeout, while ordinary getter calls must continue rejecting timed-out output."
+            $failed = $true
+        } elseif ($VerboseOutput) {
+            Write-Info 'Checked install-path probes preserve exact output captured before wrapper timeout.'
+        }
+
+        if (
+            $ensureEditorContent -notmatch "Get-UnityCliOutput\s+-Arguments\s+@\('install-path'\)\s+-AcceptCapturedOutputOnTimeout" -or
+            $ensureEditorContent -notmatch 'Invoke-UnityCliSafe[^\r\n]+-AcceptCapturedOutputPattern'
+        ) {
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Install-path getter and setter wiring must opt into exact output recovery after a wrapper timeout."
+            $failed = $true
+        }
+    } catch {
+        Write-Host "::error file=scripts/unity/ensure-editor.ps1::Install-path timeout-output regression failed: $($_.Exception.Message)"
+        $failed = $true
+    } finally {
+        ${function:Invoke-UnityCliCaptureWithTimeout} = $originalUnityCliCapture
+        if ($oldProvisioningDeadlineVariable) {
+            $script:ProvisioningDeadlineUtc = $oldProvisioningDeadline
+        } else {
+            Remove-Variable -Name ProvisioningDeadlineUtc -Scope Script -ErrorAction SilentlyContinue
+        }
+        Remove-Variable -Name unityCliCaptureResult -Scope Script -ErrorAction SilentlyContinue
     }
 
     if (

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -965,13 +965,31 @@ function Invoke-UnityCliSafe {
     # It echoes the command and surfaces any output via Write-Host so failures
     # remain diagnosable in CI logs. Captured-output callers should use
     # Get-UnityCliOutput instead; this one is for fire-and-forget effects.
-    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [string]$AcceptCapturedOutputPattern = ''
+    )
 
     $requestedTimeout = Get-EnsureEditorProbeTimeoutSeconds
     $effectiveTimeout = Get-EffectiveUnityCliTimeoutSeconds -RequestedSeconds $requestedTimeout
-    $result = Invoke-UnityCliCaptureWithTimeout -Arguments $Arguments -TimeoutSeconds $effectiveTimeout -TimeoutKnob 'UH_ENSURE_EDITOR_PROBE_TIMEOUT_SECONDS'
+    $acceptTimedOutOutput = -not [string]::IsNullOrWhiteSpace($AcceptCapturedOutputPattern)
+    $result = Invoke-UnityCliCaptureWithTimeout -Arguments $Arguments -TimeoutSeconds $effectiveTimeout -TimeoutKnob 'UH_ENSURE_EDITOR_PROBE_TIMEOUT_SECONDS' -TimeoutAsWarning:$acceptTimedOutOutput
     $exit = [int]$result.ExitCode
-    return ($exit -eq 0)
+    if ($exit -eq 0) {
+        return $true
+    }
+
+    $wrapperKilled = [bool]$result.StallKilled -or [bool]$result.TimedOutWallClock
+    if ($wrapperKilled -and $acceptTimedOutOutput) {
+        foreach ($line in @($result.Output)) {
+            if ([string]$line -match $AcceptCapturedOutputPattern) {
+                Write-CiNotice "Unity CLI emitted the expected completion output before its lingering process tree was stopped."
+                return $true
+            }
+        }
+    }
+
+    return $false
 }
 
 function Get-UnityCliOutput {
@@ -980,13 +998,20 @@ function Get-UnityCliOutput {
     # success, or $null on any failure. Does NOT echo to the success pipeline
     # of this script: the caller (run-ci-tests.ps1) reads our LAST stdout line
     # as the resolved editor path, so getter output must never leak there.
-    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [switch]$AcceptCapturedOutputOnTimeout
+    )
 
     $requestedTimeout = Get-EnsureEditorProbeTimeoutSeconds
     $effectiveTimeout = Get-EffectiveUnityCliTimeoutSeconds -RequestedSeconds $requestedTimeout
-    $result = Invoke-UnityCliCaptureWithTimeout -Arguments $Arguments -TimeoutSeconds $effectiveTimeout -TimeoutKnob 'UH_ENSURE_EDITOR_PROBE_TIMEOUT_SECONDS'
+    $result = Invoke-UnityCliCaptureWithTimeout -Arguments $Arguments -TimeoutSeconds $effectiveTimeout -TimeoutKnob 'UH_ENSURE_EDITOR_PROBE_TIMEOUT_SECONDS' -TimeoutAsWarning:$AcceptCapturedOutputOnTimeout
     if ($result.ExitCode -ne 0) {
-        return $null
+        $wrapperKilled = [bool]$result.StallKilled -or [bool]$result.TimedOutWallClock
+        if (-not $AcceptCapturedOutputOnTimeout -or -not $wrapperKilled) {
+            return $null
+        }
+        Write-CiNotice "Unity CLI output was captured before its lingering process tree was stopped."
     }
 
     # Normalize to an array of strings regardless of whether 0/1/many lines came
@@ -1144,7 +1169,8 @@ function Invoke-UnityCliCaptureWithTimeout {
         [int]$TimeoutSeconds = 2700,
         [string]$TimeoutKnob = 'UH_ENSURE_EDITOR_INSTALL_TIMEOUT_SECONDS',
         [int]$StallSeconds = -1,
-        [string]$StallKnob = 'UH_ENSURE_EDITOR_PROGRESS_STALL_SECONDS'
+        [string]$StallKnob = 'UH_ENSURE_EDITOR_PROGRESS_STALL_SECONDS',
+        [switch]$TimeoutAsWarning
     )
 
     # Default the stall threshold from the env-aware helper when the caller did
@@ -1452,10 +1478,12 @@ function Invoke-UnityCliCaptureWithTimeout {
             # killed for "no stdout/stderr line in N seconds" (this branch) versus
             # "exceeded the total wall-clock budget" (the else branch below).
             $stallKnobName = if ($StallKnob) { $StallKnob } else { 'UH_ENSURE_EDITOR_PROGRESS_STALL_SECONDS' }
-            Write-Host "::error::Unity CLI command '$($Arguments -join ' ')' HEARTBEAT STALLED after $StallSeconds second(s) with no Unity CLI stdout/stderr line; the process tree was killed (sentinel exit $stallExitCode). Raise the threshold via $stallKnobName (0 disables the heartbeat detector). Last progress message: $lastProgress. Collapsed tail:`n$collapsedTail"
+            $annotation = if ($TimeoutAsWarning) { 'warning' } else { 'error' }
+            Write-Host "::$annotation::Unity CLI command '$($Arguments -join ' ')' HEARTBEAT STALLED after $StallSeconds second(s) with no Unity CLI stdout/stderr line; the process tree was killed (sentinel exit $stallExitCode). Raise the threshold via $stallKnobName (0 disables the heartbeat detector). Last progress message: $lastProgress. Collapsed tail:`n$collapsedTail"
         } else {
             $knob = if ($TimeoutKnob) { $TimeoutKnob } else { 'UH_ENSURE_EDITOR_INSTALL_TIMEOUT_SECONDS' }
-            Write-Host "::error::Unity CLI command '$($Arguments -join ' ')' TIMED OUT after $TimeoutSeconds second(s) and the process tree was killed (sentinel exit $timeoutExitCode). Raise the limit via $knob (0 disables the timeout). Last progress message: $lastProgress. Collapsed tail:`n$collapsedTail"
+            $annotation = if ($TimeoutAsWarning) { 'warning' } else { 'error' }
+            Write-Host "::$annotation::Unity CLI command '$($Arguments -join ' ')' TIMED OUT after $TimeoutSeconds second(s) and the process tree was killed (sentinel exit $timeoutExitCode). Raise the limit via $knob (0 disables the timeout). Last progress message: $lastProgress. Collapsed tail:`n$collapsedTail"
         }
     }
 
@@ -1915,7 +1943,7 @@ function Get-UnityCliInstallRoot {
     # best-effort SET succeeded, so discovery does not depend on the (uncertain)
     # set flag. Take the last non-empty path-like stdout line; ignore banners
     # and decorated output.
-    $lines = Get-UnityCliOutput -Arguments @('install-path')
+    $lines = Get-UnityCliOutput -Arguments @('install-path') -AcceptCapturedOutputOnTimeout
     if (-not $lines) {
         return $null
     }
@@ -1950,11 +1978,13 @@ function Set-UnityCliInstallPath {
     # `--set`; if both fail, emit a ::notice:: (NOT an error) and continue.
     param([Parameter(Mandatory = $true)][string]$Root)
 
-    if (Invoke-UnityCliSafe -Arguments @('install-path', '-s', $Root)) {
+    $normalizedRoot = $Root.TrimEnd([char[]]@('\', '/'))
+    $confirmationPattern = '^All Unity Editors will be installed to\s+' + [regex]::Escape($normalizedRoot) + '[\\/]?$'
+    if (Invoke-UnityCliSafe -Arguments @('install-path', '-s', $Root) -AcceptCapturedOutputPattern $confirmationPattern) {
         return
     }
 
-    if (Invoke-UnityCliSafe -Arguments @('install-path', '--set', $Root)) {
+    if (Invoke-UnityCliSafe -Arguments @('install-path', '--set', $Root) -AcceptCapturedOutputPattern $confirmationPattern) {
         return
     }
 


### PR DESCRIPTION
## Summary
- preserve exact install-path output when the Unity CLI service process lingers past the watchdog
- accept setter recovery only for an exact confirmation pattern and only after a wrapper-driven kill
- retain fail-closed behavior for mismatched output and native non-zero exits
- downgrade expected lingering-process timeout annotations to warnings

## Live RCA
Qora PR job 87219915635 printed and applied the managed install root, but Unity CLI did not exit under NetworkService. The watchdog killed it and the old getter discarded the captured root.

## Verification
- regression was red before the production patch
- timeout-output contract covers positive, mismatch, ordinary getter, and native-exit cases
- repository preflight and validate:prepush completed successfully
- cspell and diff checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI Unity provisioning probe logic on self-hosted Windows runners; recovery is opt-in and pattern-bound, but wrong acceptance could mis-route editor installs.
> 
> **Overview**
> Fixes **CI editor provisioning** when the Unity CLI prints a valid `install-path` answer but the process tree never exits under service accounts (e.g. NetworkService)—the watchdog used to kill the CLI and **discard** captured stdout, so getters/setters looked like failed probes.
> 
> **`ensure-editor.ps1`** adds opt-in recovery on wrapper-driven kills only: `Get-UnityCliOutput -AcceptCapturedOutputOnTimeout` for the install-path getter, and `Invoke-UnityCliSafe -AcceptCapturedOutputPattern` for setters that must match an **exact** confirmation line (`All Unity Editors will be installed to …`). Mismatched captured lines and native non-zero exits still fail closed. `Invoke-UnityCliCaptureWithTimeout` gains `-TimeoutAsWarning` so these expected lingering-process kills log as **warnings** instead of errors.
> 
> **`test-unity-workflow-matrix-contract.ps1`** pins the behavior (accept on exact timeout capture, reject ordinary getters, mismatch, native exit) and asserts wiring in `ensure-editor.ps1`. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0ecd479e49a847d595670000acc07987f291d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->