### PR TITLE
Fix Unity repair timeout recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Unity CLI install-path probes hanging under service accounts**: CI-managed editor provisioning now preserves an exact install-path confirmation captured before the watchdog stops a lingering Unity CLI process tree, so NetworkService runners can continue provisioning instead of discarding the confirmed path as a failed probe.
+- **Unity repair installs timing out after materializing a usable editor**: atomic repair provisioning now continues to required-module verification when the Unity CLI exits nonzero or reaches its watchdog deadline after `Unity.exe` is resolvable, matching the base-install recovery path while still failing closed when any required CI module is absent.
 
 ## [3.5.1] - 2026-07-12
 

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -144,6 +144,7 @@ function Import-EnsureEditorWatchdogFunctions {
         'Get-CliProgressTriple',
         'Get-LastCliProgressMessage',
         'Write-CiNotice',
+        'Install-UnityEditorWithCiModules',
         'Invoke-UnityCliCaptureWithTimeout',
         'Invoke-UnityCliSafe',
         'Get-UnityCliOutput',
@@ -1693,6 +1694,95 @@ try {
 }
 
 if ($ensureEditorWatchdogImported) {
+    $repairRecoveryFunctionNames = @(
+        'Assert-UnityProvisioningBudgetCanFit',
+        'Get-UnityCiModuleIds',
+        'Confirm-UnityCliManagedInstallRoot',
+        'Write-CiNotice',
+        'Get-UnityCliModuleInstallArguments',
+        'Invoke-UnityCliCapture',
+        'Resolve-InstalledEditor',
+        'Get-MissingUnityCiModuleGroups'
+    )
+    $repairRecoveryOriginalFunctions = @{}
+    $oldProvisioningEditorPathVariable = Get-Variable -Name ProvisioningEditorPath -Scope Script -ErrorAction SilentlyContinue
+    $oldProvisioningEditorPath = if ($oldProvisioningEditorPathVariable) { $oldProvisioningEditorPathVariable.Value } else { $null }
+    try {
+        foreach ($functionName in $repairRecoveryFunctionNames) {
+            $existingFunction = Get-Item "Function:\$functionName" -ErrorAction SilentlyContinue
+            $repairRecoveryOriginalFunctions[$functionName] = if ($existingFunction) { $existingFunction.ScriptBlock } else { $null }
+        }
+
+        function script:Assert-UnityProvisioningBudgetCanFit { param([string]$Operation, [int]$MinimumSeconds) }
+        function script:Get-UnityCiModuleIds { param([string]$Profile) return @('windows-mono') }
+        function script:Confirm-UnityCliManagedInstallRoot { param([string]$Root) return $Root }
+        function script:Write-CiNotice { param([string]$Message) $script:repairRecoveryNotices.Add($Message) | Out-Null }
+        function script:Get-UnityCliModuleInstallArguments { param([string]$Verb, [string]$Version, [string[]]$ModuleIds) return @($Verb, $Version) }
+        function script:Invoke-UnityCliCapture {
+            param([string[]]$Arguments)
+            return @{
+                Success = $false
+                ExitCode = 124
+                Output = @('Progress: 50%')
+                StallKilled = $false
+                TimedOutWallClock = $true
+            }
+        }
+        function script:Resolve-InstalledEditor { param([string]$Version, [string]$Root, [switch]$ManagedOnly) return 'D:\Unity\6000.5.2f1\Editor\Unity.exe' }
+        function script:Get-MissingUnityCiModuleGroups { param([string]$EditorPath, [string]$Profile) return @($script:repairRecoveryMissingModules) }
+
+        $script:repairRecoveryNotices = New-Object System.Collections.Generic.List[string]
+        $script:repairRecoveryMissingModules = @()
+        $resolvedRepairEditor = Install-UnityEditorWithCiModules `
+            -Version '6000.5.2f1' `
+            -InstallRoot 'D:\Unity' `
+            -Reason 'live timeout regression' `
+            -Profile 'StandaloneWindowsIl2Cpp' `
+            -ManagedOnly
+        $repairRecoveryNoticeText = @($script:repairRecoveryNotices.ToArray()) -join ' '
+        $script:repairRecoveryMissingModules = @('windows-mono')
+        $missingModuleFailure = ''
+        try {
+            Install-UnityEditorWithCiModules `
+                -Version '6000.5.2f1' `
+                -InstallRoot 'D:\Unity' `
+                -Reason 'live timeout regression' `
+                -Profile 'StandaloneWindowsIl2Cpp' `
+                -ManagedOnly | Out-Null
+        } catch {
+            $missingModuleFailure = $_.Exception.Message
+        }
+        if (
+            $resolvedRepairEditor -ne 'D:\Unity\6000.5.2f1\Editor\Unity.exe' -or
+            $repairRecoveryNoticeText -notmatch 'failed with exit code 124' -or
+            $repairRecoveryNoticeText -notmatch 'verifying modules against disk' -or
+            $missingModuleFailure -notmatch 'required CI module groups.+still missing.+windows-mono'
+        ) {
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::A timed-out repair install must continue to disk module verification when Unity.exe is resolvable afterward and fail closed if required modules are absent. Resolved='$resolvedRepairEditor' Notices='$repairRecoveryNoticeText' MissingModuleFailure='$missingModuleFailure'."
+            $failed = $true
+        } elseif ($VerboseOutput) {
+            Write-Info 'Checked repair installs recover a resolvable editor after a Unity CLI timeout and still verify modules on disk.'
+        }
+    } catch {
+        Write-Host "::error file=scripts/unity/ensure-editor.ps1::Repair-install timeout recovery regression failed: $($_.Exception.Message)"
+        $failed = $true
+    } finally {
+        foreach ($functionName in $repairRecoveryFunctionNames) {
+            if ($repairRecoveryOriginalFunctions[$functionName]) {
+                Set-Item "Function:\$functionName" -Value $repairRecoveryOriginalFunctions[$functionName]
+            } else {
+                Remove-Item "Function:\$functionName" -ErrorAction SilentlyContinue
+            }
+        }
+        Remove-Variable -Name repairRecoveryNotices -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name repairRecoveryMissingModules -Scope Script -ErrorAction SilentlyContinue
+        if ($oldProvisioningEditorPathVariable) {
+            $script:ProvisioningEditorPath = $oldProvisioningEditorPath
+        } else {
+            Remove-Variable -Name ProvisioningEditorPath -Scope Script -ErrorAction SilentlyContinue
+        }
+    }
+
     $oldInstallTimeout = $env:UH_ENSURE_EDITOR_INSTALL_TIMEOUT_SECONDS
     $oldProvisioningProfileVariable = Get-Variable -Name UnityProvisioningProfile -Scope Script -ErrorAction SilentlyContinue
     $oldProvisioningProfile = if ($oldProvisioningProfileVariable) { [string]$oldProvisioningProfileVariable.Value } else { $null }

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -3015,14 +3015,14 @@ function Install-UnityEditorWithCiModules {
         # thousands of identical progress lines) so the tail is READABLE.
         $tail = Get-CollapsedCliOutputTail -Output $installResult.Output -MaxLines 40
         $resolvedAfterFailure = Resolve-InstalledEditor -Version $Version -Root $InstallRoot -ManagedOnly:$ManagedOnly
-        if ($installText -match '(?i)already installed|editor already installed|is already installed') {
-            if ($resolvedAfterFailure) {
-                Write-CiNotice "Unity repair install for $Version reported already-installed with exit code $($installResult.ExitCode), but Unity.exe is resolvable afterward; verifying modules against disk."
-                $resolved = $resolvedAfterFailure
-                $script:ProvisioningEditorPath = $resolved
-                break
-            }
+        if ($resolvedAfterFailure) {
+            Write-CiNotice "Unity repair install for $Version failed with exit code $($installResult.ExitCode), but Unity.exe is resolvable afterward; verifying modules against disk."
+            $resolved = $resolvedAfterFailure
+            $script:ProvisioningEditorPath = $resolved
+            break
+        }
 
+        if ($installText -match '(?i)already installed|editor already installed|is already installed') {
             if ($attempt -lt 2) {
                 Write-InstalledEditorDiagnostics -Version $Version -Root $InstallRoot -Reason "Unity repair install reported already-installed, but Unity.exe could not be resolved afterward."
                 Invoke-UnityVersionUninstallForRepair -Version $Version -Reason "Unity repair install reported already-installed, but Unity.exe could not be resolved." -InstallRoot $InstallRoot | Out-Null

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -3018,10 +3018,6 @@ function Install-UnityEditorWithCiModules {
         }
 
         $installText = (@($installResult.Output) -join "`n")
-        # Collapse consecutive identical lines (the Android NDK install can spam
-        # thousands of identical progress lines) only when failure diagnostics
-        # need a tail; a recovered editor does not consume it.
-        $tail = Get-CollapsedCliOutputTail -Output $installResult.Output -MaxLines 40
         if ($installText -match '(?i)already installed|editor already installed|is already installed') {
             if ($attempt -lt 2) {
                 Write-InstalledEditorDiagnostics -Version $Version -Root $InstallRoot -Reason "Unity repair install reported already-installed, but Unity.exe could not be resolved afterward."
@@ -3032,6 +3028,10 @@ function Install-UnityEditorWithCiModules {
             }
         }
 
+        # Collapse consecutive identical lines (the Android NDK install can spam
+        # thousands of identical progress lines) only for the terminal failure
+        # path; recovered editors and retryable stale installs do not consume it.
+        $tail = Get-CollapsedCliOutputTail -Output $installResult.Output -MaxLines 40
         Write-UnityCliInstallFailureAnnotation -Version $Version -Output $installResult.Output -ExitCode $installResult.ExitCode -Arguments $installArgs
         # Wrapper-driven kill state drives the diagnostic wording: the new
         # StallKilled / TimedOutWallClock fields distinguish a heartbeat-stall

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -3011,9 +3011,6 @@ function Install-UnityEditorWithCiModules {
 
         $installLines = @($installResult.Output)
         $installText = ($installLines -join "`n")
-        # Collapse consecutive identical lines (the Android NDK install can spam
-        # thousands of identical progress lines) so the tail is READABLE.
-        $tail = Get-CollapsedCliOutputTail -Output $installResult.Output -MaxLines 40
         $resolvedAfterFailure = Resolve-InstalledEditor -Version $Version -Root $InstallRoot -ManagedOnly:$ManagedOnly
         if ($resolvedAfterFailure) {
             Write-CiNotice "Unity repair install for $Version failed with exit code $($installResult.ExitCode), but Unity.exe is resolvable afterward; verifying modules against disk."
@@ -3022,6 +3019,10 @@ function Install-UnityEditorWithCiModules {
             break
         }
 
+        # Collapse consecutive identical lines (the Android NDK install can spam
+        # thousands of identical progress lines) only when failure diagnostics
+        # need a tail; a recovered editor does not consume it.
+        $tail = Get-CollapsedCliOutputTail -Output $installResult.Output -MaxLines 40
         if ($installText -match '(?i)already installed|editor already installed|is already installed') {
             if ($attempt -lt 2) {
                 Write-InstalledEditorDiagnostics -Version $Version -Root $InstallRoot -Reason "Unity repair install reported already-installed, but Unity.exe could not be resolved afterward."

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -3009,8 +3009,6 @@ function Install-UnityEditorWithCiModules {
             break
         }
 
-        $installLines = @($installResult.Output)
-        $installText = ($installLines -join "`n")
         $resolvedAfterFailure = Resolve-InstalledEditor -Version $Version -Root $InstallRoot -ManagedOnly:$ManagedOnly
         if ($resolvedAfterFailure) {
             Write-CiNotice "Unity repair install for $Version failed with exit code $($installResult.ExitCode), but Unity.exe is resolvable afterward; verifying modules against disk."
@@ -3019,6 +3017,7 @@ function Install-UnityEditorWithCiModules {
             break
         }
 
+        $installText = (@($installResult.Output) -join "`n")
         # Collapse consecutive identical lines (the Android NDK install can spam
         # thousands of identical progress lines) only when failure diagnostics
         # need a tail; a recovered editor does not consume it.


### PR DESCRIPTION
## Summary
- recover a CLI-managed Unity repair when the CLI times out or exits nonzero after materializing a resolvable `Unity.exe`
- continue through the existing required-module verification, failing closed when any CI module is absent
- pin the live Qora/HYPER 6000.5.2f1 timeout as a behavioral regression

## Evidence
- live failure: Qora run 29374353954 reached the 2700-second Unity CLI wall timeout at 50%, while the editor was resolvable afterward
- red regression before production patch: `Install-UnityEditorWithCiModules` entered failure diagnostics instead of module verification
- green focused contract: no repair-timeout regression annotation after the patch; both recovered-editor and missing-module cases pass
- `git diff --check`

## Note
The focused matrix contract currently emits a pre-existing local bootstrap detect-only annotation on this host even though that probe exits 0; it is unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI editor provisioning behavior on self-hosted runners when Unity CLI times out after partial install; scope is narrow and guarded by module verification plus a new regression test, but misclassification could still affect runner availability.
> 
> **Overview**
> **Unity repair installs** no longer treat a nonzero CLI exit or watchdog timeout as a hard failure when **`Unity.exe` is already on disk**. `Install-UnityEditorWithCiModules` in `ensure-editor.ps1` resolves the editor after a failed repair run, logs that it is **verifying modules against disk**, and proceeds like the base-install recovery path instead of jumping straight into failure diagnostics. Required CI modules are still **fail-closed** if anything is missing.
> 
> CLI output collapsing for noisy Android progress spam is deferred to the **terminal failure** path only, so recovered editors and retryable stale-install handling are not affected.
> 
> A **matrix contract regression** mocks a wall-clock timeout (exit 124) with a resolvable editor and asserts both successful recovery and missing-module failure. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e824fb2b38e3fe094f5a0347f419a68a85aa7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->