### PR TITLE
Recover locked Unity native-startup repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Unity CLI install-path probes hanging under service accounts**: CI-managed editor provisioning now preserves an exact install-path confirmation captured before the watchdog stops a lingering Unity CLI process tree, so NetworkService runners can continue provisioning instead of discarding the confirmed path as a failed probe.
 - **Unity repair installs timing out after materializing a usable editor**: atomic repair provisioning now continues to required-module verification when the Unity CLI exits nonzero or reaches its watchdog deadline after `Unity.exe` is resolvable, matching the base-install recovery path while still failing closed when any required CI module is absent.
+- **Locked corrupt editors blocking native-startup recovery**: when a failed native startup probe cannot quarantine the existing editor because another process still holds its tree, provisioning now installs and verifies the editor in the alternate CI-managed root instead of leaving the runner permanently unable to self-repair.
 
 ## [3.5.1] - 2026-07-12
 

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1312,6 +1312,35 @@ if (-not $ensureEditorPrefersAtomicModuleRepair) {
     Write-Info "Checked ensure-editor prefers healthy alternate-root reuse and alternate-root atomic repair before quarantine fallback."
 }
 
+$nativeStartupFunctionAst = Get-FunctionAstByName -Ast $ensureEditorAst -Name 'Ensure-UnityNativeStartupHealthy'
+$nativeStartupCommands = if ($nativeStartupFunctionAst) {
+    Get-FunctionCommandNames -FunctionAst $nativeStartupFunctionAst
+} else {
+    @()
+}
+$nativeStartupRepairIndex = Get-CommandIndex `
+    -Commands $nativeStartupCommands `
+    -Name 'Repair-UnityEditorWithCiModules'
+$nativeStartupPinnedFailureIndex = Get-CommandIndex `
+    -Commands $nativeStartupCommands `
+    -Name 'Test-UnityAtomicInstallFailureMayBePinnedToExistingEditor' `
+    -StartIndex ($nativeStartupRepairIndex + 1)
+$nativeStartupAlternateRootIndex = Get-CommandIndex `
+    -Commands $nativeStartupCommands `
+    -Name 'Install-UnityEditorWithCiModulesInAlternateRoot' `
+    -StartIndex ($nativeStartupPinnedFailureIndex + 1)
+if (
+    -not $nativeStartupFunctionAst -or
+    $nativeStartupRepairIndex -lt 0 -or
+    $nativeStartupPinnedFailureIndex -le $nativeStartupRepairIndex -or
+    $nativeStartupAlternateRootIndex -le $nativeStartupPinnedFailureIndex
+) {
+    Write-Host "::error file=scripts/unity/ensure-editor.ps1::Native-startup repair must fall back to an alternate CI-managed install root when quarantine/reinstall is blocked by a handle on the existing editor tree."
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info "Checked native-startup repair uses alternate-root fallback for an existing-editor-pinned quarantine failure."
+}
+
 $detectOnly = $true
 . $windowsRunnerMaintenancePath
 if (-not $detectOnly) {

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -3776,8 +3776,23 @@ function Ensure-UnityNativeStartupHealthy {
         throw "Unity $Version native startup probe failed with exit code $($result.ExitCode) ($($result.Description)), and UH_UNITY_DISABLE_EDITOR_REPAIR=1 disabled auto-repair. Probe log: $probeLog"
     }
 
+    $repairReason = "native startup probe failed with exit code $($result.ExitCode) ($($result.Description)). Probe log: $probeLog"
     Write-Host "::warning::Unity $Version native startup probe failed before the license lock; attempting one managed reinstall."
-    $repaired = Repair-UnityEditorWithCiModules -Version $Version -EditorPath $EditorPath -InstallRoot $InstallRoot -Reason "native startup probe failed with exit code $($result.ExitCode) ($($result.Description)). Probe log: $probeLog" -Profile $Profile -ManagedOnly:$ManagedOnly
+    try {
+        $repaired = Repair-UnityEditorWithCiModules -Version $Version -EditorPath $EditorPath -InstallRoot $InstallRoot -Reason $repairReason -Profile $Profile -ManagedOnly:$ManagedOnly
+    } catch {
+        $repairFailure = $_.Exception.Message
+        if (-not (Test-UnityAtomicInstallFailureMayBePinnedToExistingEditor -Message $repairFailure -InstallRoot $InstallRoot -Version $Version)) {
+            throw
+        }
+
+        Write-Host "::warning::Native-startup repair for Unity $Version could not replace the existing editor tree ($repairFailure); trying an alternate CI-managed install root."
+        try {
+            $repaired = Install-UnityEditorWithCiModulesInAlternateRoot -Version $Version -InstallRoot $InstallRoot -Reason "native-startup repair was pinned to the existing editor tree ($repairFailure)" -Profile $Profile -ManagedOnly:$ManagedOnly
+        } catch {
+            throw "Unity $Version native-startup repair was blocked at the existing editor tree ($repairFailure), and alternate-root repair also failed: $($_.Exception.Message)"
+        }
+    }
     # Repair-UnityEditorWithCiModules requests the selected provisioning profile,
     # then we re-run the disk-authoritative module check so a CLI success with
     # missing selected-profile children is still caught before the final native


### PR DESCRIPTION
## Summary
- recover a failed native-startup repair in the existing alternate CI-managed install root when a process still holds the corrupt base editor tree
- retain disk-authoritative module verification and the post-repair native startup probe
- pin the HYPERLIGHT locked-editor failure as an ordering contract

## Evidence
- live red: Qora run 29380369600 failed pre-lock after eight quarantine moves could not replace `D:\actions-runner\_work\_tool\qora-unity-editors\6000.5.2f1`
- preceding red contract required native-startup repair -> pinned-tree classification -> alternate-root install ordering
- focused matrix contract green after the patch
- `git diff --check`

## Safety
This path runs before Unity credential validation and before lock acquisition. Alternate-root output remains inside the caller's managed install root and still undergoes module and native-startup verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-lock Unity editor provisioning on self-hosted runners; behavior is narrow and reuses existing alternate-root and verification paths, but a bad classification could mis-route installs.
> 
> **Overview**
> When a **native startup probe** fails and managed repair cannot quarantine or replace the editor because another process holds the install tree, provisioning no longer stops there. **`Ensure-UnityNativeStartupHealthy`** now catches that repair failure, classifies it with **`Test-UnityAtomicInstallFailureMayBePinnedToExistingEditor`**, and retries via **`Install-UnityEditorWithCiModulesInAlternateRoot`**—the same escape hatch already used for locked atomic module repairs.
> 
> Post-repair **disk module checks** and the **native startup probe** are unchanged. A matrix contract test pins the command order (repair → pinned-tree test → alternate-root install), and the unreleased changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa75bebaefc9ed73e38441c57ccd26ad481b2e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->