### PR TITLE
Repair incomplete Unity editor payloads

### DIFF
--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1751,6 +1751,7 @@ if ($ensureEditorWatchdogImported) {
             -not $ensureEditorContent.Contains('[string[]]$RequiredEditorPayloadRelativePath') -or
             -not $ensureEditorContent.Contains('required editor payload is missing') -or
             -not $ensureEditorContent.Contains('UH_UNITY_DISABLE_EDITOR_REPAIR=1 disabled required-payload auto-repair') -or
+            -not $ensureEditorContent.Contains('Using reusable alternate-root CI editor with complete required payload') -or
             -not $ensureEditorContent.Contains('Required-payload repair for Unity') -or
             -not $ensureEditorContent.Contains('Install-UnityEditorWithCiModulesInAlternateRoot')
         ) {

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1750,9 +1750,11 @@ if ($ensureEditorWatchdogImported) {
             -not $traversalRejected -or
             -not $ensureEditorContent.Contains('[string[]]$RequiredEditorPayloadRelativePath') -or
             -not $ensureEditorContent.Contains('required editor payload is missing') -or
-            -not $ensureEditorContent.Contains('Repair-UnityEditorWithCiModules')
+            -not $ensureEditorContent.Contains('UH_UNITY_DISABLE_EDITOR_REPAIR=1 disabled required-payload auto-repair') -or
+            -not $ensureEditorContent.Contains('Required-payload repair for Unity') -or
+            -not $ensureEditorContent.Contains('Install-UnityEditorWithCiModulesInAlternateRoot')
         ) {
-            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation must reject traversal, report only missing relative files, and drive managed quarantine/reinstall before licensed work. Missing='$($missingPayload -join ',')' TraversalRejected=$traversalRejected."
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation must reject traversal, report only missing relative files, honor the repair-disable flag, and fall back to an alternate managed root when the damaged tree is locked. Missing='$($missingPayload -join ',')' TraversalRejected=$traversalRejected."
             $failed = $true
         } elseif ($VerboseOutput) {
             Write-Info 'Checked required editor payload validation and repair contract.'

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -138,6 +138,7 @@ function Import-EnsureEditorWatchdogFunctions {
         'Get-UnityCiAlternateInstallRoot',
         'Get-UnityEditorCandidates',
         'Find-UnityEditor',
+        'Get-MissingRequiredEditorPayloadPaths',
         'Test-UnityAtomicInstallFailureMayBePinnedToExistingEditor',
         'Install-UnityEditorModulesViaAtomicReinstall',
         'Get-CollapsedCliOutputTail',
@@ -1723,6 +1724,46 @@ try {
 }
 
 if ($ensureEditorWatchdogImported) {
+    $requiredPayloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unity-required-payload-" + [guid]::NewGuid().ToString('N'))
+    try {
+        $editorPath = Join-Path $requiredPayloadRoot 'Editor\Unity.exe'
+        $presentRelative = 'Data\Resources\present.meta'
+        $missingRelative = 'Data\Resources\missing.meta'
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $editorPath) | Out-Null
+        New-Item -ItemType File -Force -Path $editorPath | Out-Null
+        New-Item -ItemType Directory -Force -Path (Join-Path (Split-Path -Parent $editorPath) 'Data\Resources') | Out-Null
+        New-Item -ItemType File -Force -Path (Join-Path (Split-Path -Parent $editorPath) $presentRelative) | Out-Null
+
+        $missingPayload = @(Get-MissingRequiredEditorPayloadPaths `
+            -EditorPath $editorPath `
+            -RelativePaths @($presentRelative, $missingRelative))
+        $traversalRejected = $false
+        try {
+            Get-MissingRequiredEditorPayloadPaths -EditorPath $editorPath -RelativePaths @('..\outside.txt') | Out-Null
+        } catch {
+            $traversalRejected = $true
+        }
+
+        if (
+            $missingPayload.Count -ne 1 -or
+            $missingPayload[0] -ne $missingRelative -or
+            -not $traversalRejected -or
+            -not $ensureEditorContent.Contains('[string[]]$RequiredEditorPayloadRelativePath') -or
+            -not $ensureEditorContent.Contains('required editor payload is missing') -or
+            -not $ensureEditorContent.Contains('Repair-UnityEditorWithCiModules')
+        ) {
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation must reject traversal, report only missing relative files, and drive managed quarantine/reinstall before licensed work. Missing='$($missingPayload -join ',')' TraversalRejected=$traversalRejected."
+            $failed = $true
+        } elseif ($VerboseOutput) {
+            Write-Info 'Checked required editor payload validation and repair contract.'
+        }
+    } catch {
+        Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation regression failed: $($_.Exception.Message)"
+        $failed = $true
+    } finally {
+        Remove-Item -LiteralPath $requiredPayloadRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $repairRecoveryFunctionNames = @(
         'Assert-UnityProvisioningBudgetCanFit',
         'Get-UnityCiModuleIds',

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1724,6 +1724,8 @@ try {
 }
 
 if ($ensureEditorWatchdogImported) {
+    $alternateInstallFunctionAst = Get-FunctionAstByName -Ast $ensureEditorAst -Name 'Install-UnityEditorWithCiModulesInAlternateRoot'
+    $alternateInstallContent = if ($alternateInstallFunctionAst) { $alternateInstallFunctionAst.Extent.Text } else { '' }
     $requiredPayloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("unity-required-payload-" + [guid]::NewGuid().ToString('N'))
     try {
         $editorPath = Join-Path $requiredPayloadRoot 'Editor\Unity.exe'
@@ -1752,10 +1754,14 @@ if ($ensureEditorWatchdogImported) {
             -not $ensureEditorContent.Contains('required editor payload is missing') -or
             -not $ensureEditorContent.Contains('UH_UNITY_DISABLE_EDITOR_REPAIR=1 disabled required-payload auto-repair') -or
             -not $ensureEditorContent.Contains('Using reusable alternate-root CI editor with complete required payload') -or
+            -not $alternateInstallContent.Contains('[string[]]$RequiredEditorPayloadRelativePath = @()') -or
+            -not $alternateInstallContent.Contains('Quarantining payload-incomplete alternate-root Unity') -or
+            -not $alternateInstallContent.Contains('Get-MissingRequiredEditorPayloadPaths') -or
+            -not $ensureEditorContent.Contains('-RequiredEditorPayloadRelativePath $RequiredEditorPayloadRelativePath') -or
             -not $ensureEditorContent.Contains('Required-payload repair for Unity') -or
             -not $ensureEditorContent.Contains('Install-UnityEditorWithCiModulesInAlternateRoot')
         ) {
-            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation must reject traversal, report only missing relative files, honor the repair-disable flag, and fall back to an alternate managed root when the damaged tree is locked. Missing='$($missingPayload -join ',')' TraversalRejected=$traversalRejected."
+            Write-Host "::error file=scripts/unity/ensure-editor.ps1::Required editor payload validation must reject traversal, report only missing relative files, honor the repair-disable flag, and make alternate-root reuse and locked-tree fallback payload-aware. Missing='$($missingPayload -join ',')' TraversalRejected=$traversalRejected."
             $failed = $true
         } elseif ($VerboseOutput) {
             Write-Info 'Checked required editor payload validation and repair contract.'

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -4741,6 +4741,20 @@ if ($RequireHealthyExisting) {
 
     $missingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $editor -RelativePaths $RequiredEditorPayloadRelativePath)
     if ($missingPayload.Count -gt 0) {
+        $alternateEditor = Find-UnityCiAlternateEditorWithCiModules -Version $UnityVersion -InstallRoot $InstallRoot -Profile $ProvisioningProfile
+        if ($alternateEditor) {
+            $alternateMissingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $alternateEditor -RelativePaths $RequiredEditorPayloadRelativePath)
+            if ($alternateMissingPayload.Count -eq 0) {
+                Write-CiNotice "Using reusable alternate-root CI editor with complete required payload for Unity ${UnityVersion}: $alternateEditor"
+                $editor = $alternateEditor
+                $script:ProvisioningEditorPath = $editor
+                $missingPayload = @()
+            } else {
+                Write-CiNotice "Alternate-root CI editor for Unity $UnityVersion is also missing required editor payload: $($alternateMissingPayload -join ', ')."
+            }
+        }
+    }
+    if ($missingPayload.Count -gt 0) {
         Write-InstalledEditorDiagnostics -Version $UnityVersion -Root $InstallRoot -Reason "RequireHealthyExisting was set and required editor payload is missing: $($missingPayload -join ', ')."
         throw "Unity $UnityVersion required editor payload is missing: $($missingPayload -join ', '). CI test jobs fail fast instead of repairing when RequireHealthyExisting is set."
     }

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -4878,6 +4878,10 @@ $editor = Ensure-UnityNativeStartupHealthy -Version $UnityVersion -EditorPath $e
 $script:ProvisioningEditorPath = $editor
 $missingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $editor -RelativePaths $RequiredEditorPayloadRelativePath)
 if ($missingPayload.Count -gt 0) {
+    if ($env:UH_UNITY_DISABLE_EDITOR_REPAIR -eq '1') {
+        throw "Unity $UnityVersion required editor payload is missing ($($missingPayload -join ', ')), and UH_UNITY_DISABLE_EDITOR_REPAIR=1 disabled required-payload auto-repair."
+    }
+
     Ensure-UnityCli | Out-Null
     Set-UnityCliInstallPath -Root $InstallRoot
     if ($CiManagedOnly) {
@@ -4885,7 +4889,21 @@ if ($missingPayload.Count -gt 0) {
     }
 
     $repairReason = "required editor payload is missing: $($missingPayload -join ', ')."
-    $editor = Repair-UnityEditorWithCiModules -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Reason $repairReason -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+    try {
+        $editor = Repair-UnityEditorWithCiModules -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Reason $repairReason -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+    } catch {
+        $repairFailure = $_.Exception.Message
+        if (-not (Test-UnityAtomicInstallFailureMayBePinnedToExistingEditor -Message $repairFailure -InstallRoot $InstallRoot -Version $UnityVersion)) {
+            throw
+        }
+
+        Write-Host "::warning::Required-payload repair for Unity $UnityVersion could not replace the existing editor tree ($repairFailure); trying an alternate CI-managed install root."
+        try {
+            $editor = Install-UnityEditorWithCiModulesInAlternateRoot -Version $UnityVersion -InstallRoot $InstallRoot -Reason "required-payload repair was pinned to the existing editor tree ($repairFailure)" -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+        } catch {
+            throw "Unity $UnityVersion required-payload repair was blocked at the existing editor tree ($repairFailure), and alternate-root repair also failed: $($_.Exception.Message)"
+        }
+    }
     $script:ProvisioningEditorPath = $editor
     $editor = Ensure-UnityNativeStartupHealthy -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
     $script:ProvisioningEditorPath = $editor

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -4239,6 +4239,7 @@ function Install-UnityEditorWithCiModulesInAlternateRoot {
         [Parameter(Mandatory = $true)][string]$InstallRoot,
         [Parameter(Mandatory = $true)][string]$Reason,
         [string]$Profile = $(Get-UnityProvisioningProfile),
+        [string[]]$RequiredEditorPayloadRelativePath = @(),
         [switch]$ManagedOnly
     )
 
@@ -4262,11 +4263,17 @@ function Install-UnityEditorWithCiModulesInAlternateRoot {
             if ($existingAlternate) {
                 $existingAlternateMissing = @(Get-MissingUnityCiModuleGroups -EditorPath $existingAlternate -Profile $Profile)
                 if ($existingAlternateMissing.Count -eq 0) {
-                    Write-CiNotice "Using already repaired alternate-root CI editor for Unity $Version with provisioning profile '$Profile': $existingAlternate"
-                    return $existingAlternate
+                    $existingAlternateMissingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $existingAlternate -RelativePaths $RequiredEditorPayloadRelativePath)
+                    if ($existingAlternateMissingPayload.Count -eq 0) {
+                        Write-CiNotice "Using already repaired alternate-root CI editor for Unity $Version with provisioning profile '$Profile' and complete required payload: $existingAlternate"
+                        return $existingAlternate
+                    }
+
+                    Write-Host "::warning::Quarantining payload-incomplete alternate-root Unity $Version editor before retrying alternate-root repair: $existingAlternate (missing payload: $($existingAlternateMissingPayload -join ', '))."
+                } else {
+                    Write-Host "::warning::Quarantining partial alternate-root Unity $Version editor before retrying alternate-root repair: $existingAlternate (missing modules: $($existingAlternateMissing -join ', '))."
                 }
 
-                Write-Host "::warning::Quarantining partial alternate-root Unity $Version editor before retrying alternate-root repair: $existingAlternate (missing: $($existingAlternateMissing -join ', '))."
                 Move-UnityVersionInstallToQuarantine -Version $Version -InstallRoot $alternateRoot
             }
 
@@ -4278,6 +4285,10 @@ function Install-UnityEditorWithCiModulesInAlternateRoot {
             $missing = @(Get-MissingUnityCiModuleGroups -EditorPath $resolved -Profile $Profile)
             if ($missing.Count -gt 0) {
                 throw "Alternate-root Unity $Version install completed at '$resolved', but required CI module groups for provisioning profile '$Profile' are still missing on disk: $($missing -join ', ')."
+            }
+            $missingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $resolved -RelativePaths $RequiredEditorPayloadRelativePath)
+            if ($missingPayload.Count -gt 0) {
+                throw "Alternate-root Unity $Version install completed at '$resolved', but required editor payload is still missing on disk: $($missingPayload -join ', ')."
             }
             if ($ManagedOnly -and -not (Test-IsPathInsideDirectory -Path $resolved -Directory $InstallRoot)) {
                 throw "Alternate-root Unity $Version install resolved outside the managed install root '$InstallRoot': $resolved"
@@ -4913,7 +4924,7 @@ if ($missingPayload.Count -gt 0) {
 
         Write-Host "::warning::Required-payload repair for Unity $UnityVersion could not replace the existing editor tree ($repairFailure); trying an alternate CI-managed install root."
         try {
-            $editor = Install-UnityEditorWithCiModulesInAlternateRoot -Version $UnityVersion -InstallRoot $InstallRoot -Reason "required-payload repair was pinned to the existing editor tree ($repairFailure)" -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+            $editor = Install-UnityEditorWithCiModulesInAlternateRoot -Version $UnityVersion -InstallRoot $InstallRoot -Reason "required-payload repair was pinned to the existing editor tree ($repairFailure)" -Profile $ProvisioningProfile -RequiredEditorPayloadRelativePath $RequiredEditorPayloadRelativePath -ManagedOnly:$CiManagedOnly
         } catch {
             throw "Unity $UnityVersion required-payload repair was blocked at the existing editor tree ($repairFailure), and alternate-root repair also failed: $($_.Exception.Message)"
         }

--- a/scripts/unity/ensure-editor.ps1
+++ b/scripts/unity/ensure-editor.ps1
@@ -16,6 +16,8 @@ param(
 
     [switch]$WithWindowsIl2Cpp,
 
+    [string[]]$RequiredEditorPayloadRelativePath = @(),
+
     [switch]$RequireHealthyExisting
 )
 
@@ -2243,6 +2245,40 @@ function Test-IsPathInsideDirectory {
     return $fullPath.Equals($fullDirectory, $comparison) -or
         $fullPath.StartsWith($fullDirectory + [System.IO.Path]::DirectorySeparatorChar, $comparison) -or
         $fullPath.StartsWith($fullDirectory + [System.IO.Path]::AltDirectorySeparatorChar, $comparison)
+}
+
+function Get-MissingRequiredEditorPayloadPaths {
+    param(
+        [Parameter(Mandatory = $true)][string]$EditorPath,
+        [string[]]$RelativePaths = @()
+    )
+
+    $editorRoot = Split-Path -Parent $EditorPath
+    if (-not $editorRoot) {
+        throw "Could not resolve the Unity editor root from '$EditorPath'."
+    }
+
+    $missing = New-Object System.Collections.Generic.List[string]
+    $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($relativePath in @($RelativePaths)) {
+        $relative = [string]$relativePath
+        if ([string]::IsNullOrWhiteSpace($relative)) {
+            throw 'Required editor payload paths must be non-empty relative paths.'
+        }
+        if ([System.IO.Path]::IsPathRooted($relative)) {
+            throw "Required editor payload path must be relative to the Editor directory: '$relative'."
+        }
+
+        $candidate = [System.IO.Path]::GetFullPath((Join-Path $editorRoot $relative))
+        if (-not (Test-IsPathInsideDirectory -Path $candidate -Directory $editorRoot)) {
+            throw "Required editor payload path escapes the Editor directory: '$relative'."
+        }
+        if ($seen.Add($relative) -and -not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            $missing.Add($relative)
+        }
+    }
+
+    return @($missing.ToArray())
 }
 
 function Get-UnityEditorInstallDirectory {
@@ -4703,6 +4739,12 @@ if ($RequireHealthyExisting) {
         throw "Unity $UnityVersion is missing required CI module groups for provisioning profile '$ProvisioningProfile': $($missingModules -join ', '). CI test jobs fail fast instead of installing modules in-job; run scripts/unity/maintain-windows-runner.ps1 or dispatch .github/workflows/runner-bootstrap.yml to repair this editor."
     }
 
+    $missingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $editor -RelativePaths $RequiredEditorPayloadRelativePath)
+    if ($missingPayload.Count -gt 0) {
+        Write-InstalledEditorDiagnostics -Version $UnityVersion -Root $InstallRoot -Reason "RequireHealthyExisting was set and required editor payload is missing: $($missingPayload -join ', ')."
+        throw "Unity $UnityVersion required editor payload is missing: $($missingPayload -join ', '). CI test jobs fail fast instead of repairing when RequireHealthyExisting is set."
+    }
+
     if ($env:UH_UNITY_SKIP_NATIVE_STARTUP_PROBE -eq '1') {
         Write-CiNotice "Skipping Unity $UnityVersion native startup probe (UH_UNITY_SKIP_NATIVE_STARTUP_PROBE=1)."
     } else {
@@ -4834,6 +4876,25 @@ if (-not $editor) {
 
 $editor = Ensure-UnityNativeStartupHealthy -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
 $script:ProvisioningEditorPath = $editor
+$missingPayload = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $editor -RelativePaths $RequiredEditorPayloadRelativePath)
+if ($missingPayload.Count -gt 0) {
+    Ensure-UnityCli | Out-Null
+    Set-UnityCliInstallPath -Root $InstallRoot
+    if ($CiManagedOnly) {
+        Confirm-UnityCliManagedInstallRoot -Root $InstallRoot | Out-Null
+    }
+
+    $repairReason = "required editor payload is missing: $($missingPayload -join ', ')."
+    $editor = Repair-UnityEditorWithCiModules -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Reason $repairReason -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+    $script:ProvisioningEditorPath = $editor
+    $editor = Ensure-UnityNativeStartupHealthy -Version $UnityVersion -EditorPath $editor -InstallRoot $InstallRoot -Profile $ProvisioningProfile -ManagedOnly:$CiManagedOnly
+    $script:ProvisioningEditorPath = $editor
+
+    $missingAfterRepair = @(Get-MissingRequiredEditorPayloadPaths -EditorPath $editor -RelativePaths $RequiredEditorPayloadRelativePath)
+    if ($missingAfterRepair.Count -gt 0) {
+        throw "Unity $UnityVersion repair completed, but required editor payload is missing: $($missingAfterRepair -join ', ')."
+    }
+}
 $script:ProvisioningFinalClassification = 'success'
 Write-CiNotice "Unity editor resolved: $editor"
 Write-Output $editor


### PR DESCRIPTION
## Summary
- let consumers declare required files inside a Unity editor payload
- reject absolute/traversing payload paths
- fail closed for healthy-existing audits
- quarantine/reinstall managed editors whose required payload is incomplete, then revalidate

## RCA
Qora's Unity 6000.5 editor was originally installed under a path whose required Render Pipelines Core `.meta` file reached 260+ characters. Unity omitted that metadata even with Windows long paths enabled, leaving `MaterialReferenceChanger` out of the materialized package assembly.

## Verification
- red contract: missing helper function and payload behavior
- PowerShell AST parse: green
- PowerShell invocation lint: green
- Unity workflow/runner contract including payload test: green
- `git diff --check`: green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes self-hosted Unity editor provisioning and repair paths; mis-specified required paths or aggressive repair could quarantine editors or fail CI jobs, but behavior is gated by optional parameters and existing env flags.
> 
> **Overview**
> Adds **required editor payload** checks to `ensure-editor.ps1` so callers can pass `-RequiredEditorPayloadRelativePath` with paths relative to the Editor folder (e.g. package `.meta` files that can be omitted on long Windows paths).
> 
> **`Get-MissingRequiredEditorPayloadPaths`** resolves paths under the editor root, rejects absolute or traversing entries, dedupes case-insensitively, and returns only missing leaf files.
> 
> Provisioning now treats payload like CI modules: with **`RequireHealthyExisting`**, missing required files fail fast (with optional reuse of an alternate-root editor that has a complete payload). Otherwise, after modules and native startup, missing payload triggers **in-place repair**, then **alternate-root install** when the tree is pinned—unless **`UH_UNITY_DISABLE_EDITOR_REPAIR=1`**. Alternate-root reuse/install paths **quarantine** editors that lack modules or required payload and **revalidate** after install.
> 
> The Unity workflow matrix contract test imports the new helper and asserts traversal rejection, repair-disable messaging, and payload-aware alternate-root behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956d03f75a4972912043d61da740f8dc6dd9586f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->