### PR TITLE
fix(ci): use org secrets without approval gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -387,7 +387,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -325,7 +325,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -409,7 +409,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -56,7 +56,6 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected)
       }}
-    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -194,7 +193,6 @@ jobs:
           github.event.pull_request.head.repo.full_name == github.repository) &&
         (github.event_name != 'push' || github.ref_protected)
       }}
-    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
@@ -303,7 +301,6 @@ jobs:
         (github.event_name != 'push' || github.ref_protected) &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
-    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -491,7 +488,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -566,7 +563,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -651,7 +648,6 @@ jobs:
         needs.matrix-config.outputs.has-required-secrets == 'true' &&
         needs.matrix-config.outputs.matrix-include-standalone != '[]'
       }}
-    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -834,7 +830,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -909,7 +905,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -1005,7 +1001,6 @@ jobs:
           needs.unity-tests-standalone.result == 'skipped') &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
-    environment: unity-license
     runs-on: [self-hosted, Windows, RAM-64GB]
     timeout-minutes: 1200
     strategy:
@@ -1162,7 +1157,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1232,7 +1227,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1295,7 +1290,6 @@ jobs:
         needs.unity-tests-single-threaded.result == 'success' &&
         needs.matrix-config.outputs.has-required-secrets == 'true'
       }}
-    environment: unity-license
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -1319,7 +1313,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1362,7 +1356,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@f39ee38533b20592aa0fdf72b3e18d07c46325f3
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}

--- a/docs/runbooks/unity-runners-after-transfer.md
+++ b/docs/runbooks/unity-runners-after-transfer.md
@@ -203,3 +203,5 @@ The Unity workflows expect the following repository (or organization) secrets. T
 - `BUILD_LOCK_APP_ID`, `BUILD_LOCK_APP_PRIVATE_KEY` — dedicated GitHub App credentials for the `wallstop-organization-builds` organization build lock (`Ambiguous-Interactive/ambiguous-organization-build-lock`); both are required together and should be provisioned as organization secrets with access to this repository.
 - `UNITY_ACCELERATOR_ENDPOINT` — optional; enables the Unity Accelerator cache namespace when set.
 - `RUNNER_AUDIT_PAT` — optional; upgrades the runner-preflight soft pass to a hard pass (see above).
+
+Provision the required Unity and build-lock credentials as organization secrets selected for this repository. The licensed workflows intentionally do not bind jobs to a per-repository environment, so trusted pull requests from branches in this repository validate automatically without an environment approval. Pull requests from forks remain ineligible for licensed jobs and do not receive these secrets.

--- a/scripts/tests/test-portable-cleanup-classifier.js
+++ b/scripts/tests/test-portable-cleanup-classifier.js
@@ -87,7 +87,22 @@ for (const job of [
     /github\.event_name\s*!=\s*'pull_request'\s*&&/u,
     `${job} must not reject every pull request`
   );
-  assert.match(block, /^    environment:\s*unity-license\s*$/mu, `${job} must use unity-license`);
+  assert.doesNotMatch(
+    block,
+    /^    environment:\s*unity-license\s*$/mu,
+    `${job} must use organization secrets without an approval-gated environment`
+  );
+}
+for (const workflowName of ["unity-tests.yml", "unity-benchmarks.yml", "release.yml"]) {
+  const licensedWorkflow = fs.readFileSync(
+    path.join(root, ".github/workflows", workflowName),
+    "utf8"
+  );
+  assert.doesNotMatch(
+    licensedWorkflow,
+    /^\s+environment:\s*unity-license\s*$/mu,
+    `${workflowName} must not require a per-repository Unity environment`
+  );
 }
 assert.match(
   workflow,

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -9,6 +9,7 @@ param([switch]$VerboseOutput)
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $buildLockActionCommit = '092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315'
+$buildLockActionVersion = 'v1.7.1'
 
 function Write-Info($msg) {
     if ($VerboseOutput) { Write-Host "[test-unity-workflow-matrix-contract] $msg" -ForegroundColor Cyan }
@@ -271,10 +272,11 @@ function Test-UnityLockCleanupIsGated {
     $returnUses = './.github/actions/return-unity-license'
     $requiredCleanupGate = 'if: ${{ always() && steps.unity_lock.outcome == ''success'' }}'
     $requiredReleaseGate = 'if: ${{ always() && (steps.unity_lock.outcome == ''success'' || steps.unity_lock.outcome == ''failure'' || steps.unity_lock.outcome == ''cancelled'') }}'
+    $buildLockUsesLineSuffix = '[ \t]+# ' + [regex]::Escape($buildLockActionVersion) + '[ \t]*\r?$'
 
-    $acquirePattern = '(?ms)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:.*?\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + '[ \t]*\r?$'
+    $acquirePattern = '(?m)- name: Acquire organization Unity lock\s*\r?\n\s+id:\s+unity_lock\s*\r?\n(?:[^\r\n]*\r?\n)*?\s+uses:\s+' + [regex]::Escape($acquireUses) + $buildLockUsesLineSuffix
     $returnPattern = '(?ms)- name: Return Unity license\s*\r?\n\s+id:\s+return_unity_license\s*\r?\n\s+' + [regex]::Escape($requiredCleanupGate) + '\s*\r?\n\s+timeout-minutes:\s+5\s*\r?\n\s+continue-on-error:\s+true\s*\r?\n\s+uses:\s+' + [regex]::Escape($returnUses)
-    $releasePattern = '(?ms)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredReleaseGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + '[ \t]*\r?$'
+    $releasePattern = '(?m)- name: Release organization Unity lock\s*\r?\n\s+' + [regex]::Escape($requiredReleaseGate) + '\s*\r?\n\s+uses:\s+' + [regex]::Escape($releaseUses) + $buildLockUsesLineSuffix
     $failures = @()
 
     foreach ($job in $Jobs.GetEnumerator()) {
@@ -379,7 +381,7 @@ function Test-UnityLockAppConfiguration {
             "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@$buildLockActionCommit"
         }
 
-        $exactActionPattern = '(?m)^\s+uses:\s+' + [regex]::Escape($expectedAction) + '[ \t]*\r?$'
+        $exactActionPattern = '(?m)^\s+uses:\s+' + [regex]::Escape($expectedAction) + '[ \t]+# ' + [regex]::Escape($buildLockActionVersion) + '[ \t]*\r?$'
         if ($stepText -notmatch $exactActionPattern) {
             $failures += "$stepKind lock step must use $expectedAction"
         }

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -8,7 +8,7 @@ param([switch]$VerboseOutput)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$buildLockActionCommit = 'f39ee38533b20592aa0fdf72b3e18d07c46325f3'
+$buildLockActionCommit = '092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315'
 
 function Write-Info($msg) {
     if ($VerboseOutput) { Write-Host "[test-unity-workflow-matrix-contract] $msg" -ForegroundColor Cyan }


### PR DESCRIPTION
## Summary

- remove the per-repository `unity-license` environment from trusted Unity test jobs so same-repository pull requests do not require manual approval
- keep fork pull requests ineligible for licensed jobs and keep secret presence checks fail-closed
- pin acquire/release to the immutable v1.7.1 lock commit while retaining readable version comments
- document the organization-secret model and add policy regression coverage

## Validation

- `node scripts/tests/test-portable-cleanup-classifier.js` (red before workflow patch, green after)
- `npm run validate:prepush` (pass)
- `actionlint` syntax and semantic checks on the three changed workflows (pass; shellcheck integration on benchmark/release was separately disabled after the installed shellcheck process stalled)
- `scripts/tests/test-unity-workflow-matrix-contract.ps1` reached a bounded 15-minute timeout on this Windows ARM64 PowerShell host while continuously CPU-active; GitHub CI remains the authoritative run

## Security behavior

Trusted same-repository pull requests can use the selected organization secrets automatically. Fork pull requests remain rejected by the existing repository-identity job guards and do not receive secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Unity license and build-lock secrets reach CI (org secrets on trusted same-repo PRs without environment approval); fork isolation relies on existing job `if` guards remaining correct.
> 
> **Overview**
> Licensed Unity jobs no longer bind to the per-repository **`unity-license`** environment, so **same-repository pull requests** can run Unity tests, benchmarks, release export, and smoke jobs **without manual environment approval**. Existing **fork PR guards** and **fail-closed secret checks** are unchanged—fork PRs still skip licensed work and do not receive secrets.
> 
> **Organization build-lock** `acquire-build-lock` / `release-build-lock` steps in `release.yml`, `unity-benchmarks.yml`, and `unity-tests.yml` are pinned to immutable commit **`092fb0dd…`** with an inline **`# v1.7.1`** comment (replacing the previous SHA).
> 
> The Unity runners runbook documents provisioning Unity and build-lock credentials as **org secrets** scoped to this repo. Regression tests now **forbid** `environment: unity-license` on licensed workflows and assert the new lock action pin in the matrix contract test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28ff211464a6a36b639f347c74752705be8e0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->