### PR TITLE
fix(ci): fail closed when Unity runners are unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -387,7 +387,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}
@@ -387,7 +387,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: release-${{ needs.release-ready.outputs.package-version }}

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -105,7 +105,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require the selected Unity runner online
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}

--- a/.github/workflows/runner-bootstrap.yml
+++ b/.github/workflows/runner-bootstrap.yml
@@ -100,128 +100,16 @@ jobs:
     name: Self-hosted runner access preflight
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB,${{ inputs.runner-label }}"
-          REQUIRED_RUNNER_NAME: ${{ inputs.runner-label }}
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml and
-        # unity-tests.yml. CRITICAL: this preflight must NEVER make CI more broken
-        # than the no-preflight baseline -- if both runner-inventory endpoints
-        # return 403/404, soft-pass with a ::warning::. When the inventory IS
-        # visible AND the named runner is offline, hard-fail (operator action
-        # required before bootstrap can dispatch).
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          echo "Required runner name: ${REQUIRED_RUNNER_NAME}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select((($labels - ((.labels // []) | map(.name))) | length) == 0)
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "Bootstrap cannot dispatch. Bring the target runner online first."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          # F12: the label match above is necessary but not sufficient when the
-          # operator named a SPECIFIC runner. Require that the named runner is
-          # also online and carries the full required label set (otherwise the
-          # bootstrap job would queue forever or the identity step would
-          # HARD-FAIL on a mislabelled runner).
-          named_online="$(jq --arg name "${REQUIRED_RUNNER_NAME}" '
-            [ .[] | select(.name == $name) | select(.status == "online") ] | length
-          ' < "${runners_json}")"
-          echo "Named runner online (name='${REQUIRED_RUNNER_NAME}'): ${named_online}"
-          if [ "${named_online}" -lt 1 ]; then
-            {
-              echo "::error::Requested runner '${REQUIRED_RUNNER_NAME}' is not currently online."
-              echo "Bring it online via Settings -> Runners (or the runner-host service) before dispatching."
-              echo "See docs/runbooks/unity-runners-after-transfer.md."
-            }
-            jq --arg name "${REQUIRED_RUNNER_NAME}" '
-              [ .[] | select(.name == $name) | {name, status, busy, labels: [(.labels // [])[].name]} ]
-            ' < "${runners_json}"
-            exit 1
-          fi
-          named_matching="$(jq --arg name "${REQUIRED_RUNNER_NAME}" --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [
-              .[]
-              | select(.name == $name)
-              | select(.status == "online")
-              | select((($labels - ((.labels // []) | map(.name))) | length) == 0)
-            ] | length
-          ' < "${runners_json}")"
-          echo "Named runner has required labels (name='${REQUIRED_RUNNER_NAME}'): ${named_matching}"
-          if [ "${named_matching}" -lt 1 ]; then
-            {
-              echo "::error::Requested runner '${REQUIRED_RUNNER_NAME}' is online but does not expose every required label (${REQUIRED_LABELS})."
-              echo "Add a custom '${REQUIRED_RUNNER_NAME}' label to that runner before dispatching bootstrap."
-              echo "See docs/runbooks/unity-runners-after-transfer.md."
-            }
-            jq --arg name "${REQUIRED_RUNNER_NAME}" '
-              [ .[] | select(.name == $name) | {name, status, busy, labels: [(.labels // [])[].name]} ]
-            ' < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require the selected Unity runner online
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB","${{ inputs.runner-label }}"]]'
 
   bootstrap:
     # F9: surface the mode (Audit vs Maintenance) in the job display name so

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -90,7 +90,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -257,7 +257,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -341,7 +341,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-benchmarks.yml
+++ b/.github/workflows/unity-benchmarks.yml
@@ -83,86 +83,18 @@ jobs:
 
   runner-preflight:
     name: Self-hosted runner access preflight
-    # See docs/runbooks/unity-runners-after-transfer.md for the design
-    # contract. CRITICAL: this preflight must NEVER make Unity CI more
-    # broken than the no-preflight baseline -- if both runner-inventory
-    # endpoints return 403/404, soft-pass with a ::warning::.
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select((($labels - ((.labels // []) | map(.name))) | length) == 0)
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The Unity matrix would queue forever."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   benchmarks:
     name: Benchmarks ${{ matrix.unity-version }} ${{ matrix.test-mode }}
@@ -325,7 +257,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -409,7 +341,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -176,17 +176,6 @@ jobs:
 
   runner-preflight:
     name: Self-hosted runner access preflight
-    # Runs on ubuntu-latest BEFORE any self-hosted matrix entry tries to
-    # queue. This converts the "stuck forever" failure mode that motivated
-    # docs/runbooks/unity-runners-after-transfer.md into a fast,
-    # clearly-explained failure. The runbook explains the post-transfer
-    # runner-group ACL pitfall and the resolution paths.
-    #
-    # CRITICAL CONTRACT: this preflight must NEVER make Unity CI more
-    # broken than the no-preflight baseline. If the token cannot list
-    # either the org-level OR repo-level runner inventory (403/404 from
-    # both), the preflight emits a ::warning:: and exits 0 (soft pass).
-    # Only when we can prove the inventory is wrong do we fail hard.
     if: >-
       ${{
         (github.event_name != 'pull_request' ||
@@ -195,95 +184,16 @@ jobs:
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      actions: read
-      # NOTE: `administration: read` is NOT a valid permissions key for
-      # workflow GITHUB_TOKEN (per actionlint and the GitHub docs schema).
-      # Listing self-hosted runners requires admin:org (org-scope) OR a
-      # fine-grained PAT with repo "Administration: read" -- neither of
-      # which the default GITHUB_TOKEN can carry. The soft-pass path in
-      # the run script below is the supported coverage when the token
-      # is unscoped. See docs/runbooks/unity-runners-after-transfer.md.
     concurrency:
       group: ${{ github.workflow }}-runner-preflight-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Probe self-hosted runner availability
-        env:
-          GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}
-          REQUIRED_LABELS: "self-hosted,Windows,RAM-64GB"
-        # Repeated literal of the labels list. Keep in sync with unity-tests
-        # `runs-on:` declaration below; this preflight must run before any
-        # self-hosted matrix in this workflow.
-        # gh api --paginate | jq -s pattern mirrors stuck-job-watchdog.yml;
-        # see that file's comments for why `jq -s` is required.
-        run: |
-          set -euo pipefail
-          echo "::group::Runner-access preflight"
-          echo "Required labels: ${REQUIRED_LABELS}"
-          IFS=',' read -r -a required <<< "${REQUIRED_LABELS}"
-          runners_json="$(mktemp)"
-          runners_scope=""
-          # 1) Try the ORG-scoped endpoint first. Self-hosted runners live
-          # at org scope in this repo (group "Default" in Ambiguous-Interactive).
-          # The default GITHUB_TOKEN often lacks admin:org and will 403 here.
-          if gh api --paginate \
-              "orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners?per_page=100" \
-              2>/dev/null \
-              | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-            runners_scope="org"
-          else
-            # 2) Fall back to the REPO-scoped endpoint. Requires
-            # administration:read; less common to be granted but possible.
-            if gh api --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
-                2>/dev/null \
-                | jq -s '[.[] | (.runners // [])[]]' > "${runners_json}" 2>/dev/null; then
-              runners_scope="repo"
-            fi
-          fi
-          if [ -z "${runners_scope}" ]; then
-            # 3) Soft pass: both endpoints failed (almost certainly the
-            # default GITHUB_TOKEN lacks scope). DO NOT fail the build --
-            # that would make Unity CI strictly more broken than baseline.
-            # The watchdog + manual unstick workflows still cover the
-            # actually-stuck case.
-            org_url="orgs/${GITHUB_REPOSITORY_OWNER}/actions/runners"
-            repo_url="repos/${GITHUB_REPOSITORY}/actions/runners"
-            {
-              echo "::warning::Runner inventory unavailable from both ${org_url}"
-              echo "::warning::and ${repo_url} (likely 403: GITHUB_TOKEN lacks admin:org"
-              echo "::warning::or administration:read)."
-              echo "::warning::See docs/runbooks/unity-runners-after-transfer.md"
-              echo "::warning::for how to plumb a RUNNER_AUDIT_PAT secret to upgrade"
-              echo "::warning::this soft-pass to a hard-pass."
-            }
-            echo "Soft pass: skipping runner inventory check."
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "Runner inventory scope: ${runners_scope}"
-          total="$(jq 'length' < "${runners_json}")"
-          echo "Visible runners (${runners_scope} scope): ${total}"
-          # Find at least one ONLINE runner with all required labels.
-          matched="$(jq --argjson labels "$(printf '%s\n' "${required[@]}" | jq -R . | jq -s .)" '
-            [ .[]
-              | select(.status == "online")
-              | select((($labels - ((.labels // []) | map(.name))) | length) == 0)
-            ] | length
-          ' < "${runners_json}")"
-          echo "Runners satisfying ${REQUIRED_LABELS}: ${matched}"
-          if [ "${matched}" -lt 1 ]; then
-            {
-              echo "::error::No online self-hosted runner satisfies the required labels (${REQUIRED_LABELS})."
-              echo "The Unity matrix would queue forever."
-              echo "See docs/runbooks/unity-runners-after-transfer.md for the post-transfer runner-group ACL fix."
-            }
-            jq '[ .[] | {name, status, busy, labels: [(.labels // [])[].name]} ]' \
-              < "${runners_json}"
-            exit 1
-          fi
-          echo "::endgroup::"
+      - name: Require an online Unity runner
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        with:
+          reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
+          reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
+          required-label-sets: '[["self-hosted","Windows","RAM-64GB"]]'
 
   # FAST tier: editmode + playmode across all versions. The expensive standalone
   # IL2CPP legs live in unity-tests-standalone, which `needs:` this job -- so a
@@ -488,7 +398,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -563,7 +473,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -830,7 +740,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -905,7 +815,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -1157,7 +1067,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1227,7 +1137,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1313,7 +1223,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1356,7 +1266,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315 # v1.7.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1388,3 +1298,79 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
           overwrite: true
+
+  unity-ci-success:
+    name: Unity CI Success
+    if: ${{ always() }}
+    needs:
+      - matrix-config
+      - runner-preflight
+      - unity-tests
+      - unity-tests-standalone
+      - unity-tests-single-threaded
+      - unitypackage-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every expected Unity CI job result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          CURRENT_REPOSITORY: ${{ github.repository }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          MATRIX_CONFIG_RESULT: ${{ needs.matrix-config.result }}
+          RUNNER_PREFLIGHT_RESULT: ${{ needs.runner-preflight.result }}
+          UNITY_TESTS_RESULT: ${{ needs.unity-tests.result }}
+          STANDALONE_RESULT: ${{ needs.unity-tests-standalone.result }}
+          SINGLE_THREADED_RESULT: ${{ needs.unity-tests-single-threaded.result }}
+          UNITYPACKAGE_SMOKE_RESULT: ${{ needs.unitypackage-smoke.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ "${PR_HEAD_REPOSITORY}" != "${CURRENT_REPOSITORY}" ]; then
+            expected="skipped"
+            for result in \
+              "${MATRIX_CONFIG_RESULT}" \
+              "${RUNNER_PREFLIGHT_RESULT}" \
+              "${UNITY_TESTS_RESULT}" \
+              "${STANDALONE_RESULT}" \
+              "${SINGLE_THREADED_RESULT}" \
+              "${UNITYPACKAGE_SMOKE_RESULT}"; do
+              if [ "${result}" != "${expected}" ]; then
+                echo "::error::Unexpected Unity CI job result for an intentionally unlicensed fork PR: ${result}."
+                exit 1
+              fi
+            done
+            echo "Fork PR intentionally omitted licensed Unity jobs."
+            exit 0
+          fi
+
+          if [ "${EVENT_NAME}" = "push" ] && [ "${REF_PROTECTED}" != "true" ]; then
+            echo "Unprotected push intentionally omitted licensed Unity jobs."
+            exit 0
+          fi
+
+          failed="false"
+          require_result() {
+            job="$1"
+            actual="$2"
+            allowed="$3"
+            case ",${allowed}," in
+              *,"${actual}",*) ;;
+              *)
+                echo "::error::Unexpected Unity CI job result: ${job}=${actual}; expected ${allowed}."
+                failed="true"
+                ;;
+            esac
+          }
+
+          require_result "matrix-config" "${MATRIX_CONFIG_RESULT}" "success"
+          require_result "runner-preflight" "${RUNNER_PREFLIGHT_RESULT}" "success"
+          require_result "unity-tests" "${UNITY_TESTS_RESULT}" "success"
+          require_result "unity-tests-standalone" "${STANDALONE_RESULT}" "success,skipped"
+          require_result "unity-tests-single-threaded" "${SINGLE_THREADED_RESULT}" "success"
+          require_result "unitypackage-smoke" "${UNITYPACKAGE_SMOKE_RESULT}" "success"
+
+          if [ "${failed}" = "true" ]; then
+            exit 1
+          fi

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -189,7 +189,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Require an online Unity runner
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           reader-app-id: ${{ secrets.BUILD_LOCK_READER_APP_ID }}
           reader-app-private-key: ${{ secrets.BUILD_LOCK_READER_APP_PRIVATE_KEY }}
@@ -398,7 +398,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -473,7 +473,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -740,7 +740,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -815,7 +815,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}
@@ -1067,7 +1067,7 @@ jobs:
       - name: Acquire organization Unity lock
         id: unity_lock
         if: ${{ steps.compute.outputs.is-empty != 'true' }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1137,7 +1137,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: ${{ matrix.unity-version }}-${{ matrix.test-mode }}-single-threaded
@@ -1223,7 +1223,7 @@ jobs:
 
       - name: Acquire organization Unity lock
         id: unity_lock
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/acquire-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}
@@ -1266,7 +1266,7 @@ jobs:
 
       - name: Release organization Unity lock
         if: ${{ always() && (steps.unity_lock.outcome == 'success' || steps.unity_lock.outcome == 'failure' || steps.unity_lock.outcome == 'cancelled') }}
-        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@c9d7e9feda64700c00374ffcbcc9dd93553c7054 # v1.8.1
+        uses: Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/release-build-lock@a8d43dd87a938f1b3417fd8a9310354bf38e2fd1 # v1.8.2
         with:
           lock-name: wallstop-organization-builds
           holder-id-suffix: unitypackage-smoke-${{ github.run_id }}

--- a/docs/runbooks/unity-runners-after-transfer.md
+++ b/docs/runbooks/unity-runners-after-transfer.md
@@ -37,12 +37,12 @@ gh api orgs/<org>/actions/runner-groups/<group-id>/repositories \
   -q '.repositories[] | {id, name, full_name}'
 ```
 
-If `wallstop/unity-helpers` does not appear in that list, the dispatcher has no path to the group's runners from this repository, which matches the symptom above.
+If `Ambiguous-Interactive/unity-helpers` does not appear in that list, the dispatcher has no path to the group's runners from this repository, which matches the symptom above.
 
 Cross-check by listing runners that the repository itself can see:
 
 ```bash
-gh api repos/wallstop/unity-helpers/actions/runners \
+gh api repos/Ambiguous-Interactive/unity-helpers/actions/runners \
   -q '.runners[] | {id, name, status, busy, labels: [.labels[].name]}'
 ```
 
@@ -78,21 +78,13 @@ After applying the chosen resolution, re-run the queued workflow from the Action
 
 ## Preflight diagnostic in this repository
 
-Unity workflows run a `runner-preflight` job on `ubuntu-latest` before the self-hosted matrix. That preflight queries `gh api orgs/${OWNER}/actions/runners` first and, on 403/404 (the default `secrets.GITHUB_TOKEN` cannot list org-scoped runners under most org policies), falls back to `gh api repos/${GITHUB_REPOSITORY}/actions/runners`. If both endpoints fail (typically a 403 from each because the token is unscoped for runner administration), the preflight emits a `::warning::` and exits 0 (soft pass).
+Unity workflows run a `runner-preflight` job on `ubuntu-latest` before the self-hosted matrix. The preflight uses the organization reader GitHub App and requests only organization self-hosted-runner read permission. It asks GitHub for runner groups visible to `Ambiguous-Interactive/unity-helpers`, then considers only runners inside those groups when matching the exact `runs-on` labels.
 
-**Critical contract:** the preflight must NEVER be more strict than the no-preflight baseline. Its only job is to surface a fast, clear failure when it can _prove_ the runner inventory is wrong. When it cannot prove that, it soft-passes so Unity CI is never made strictly more broken than it was without the preflight.
+The preflight fails closed. Missing reader credentials, an App authentication or API failure, no runner group visible to this repository, malformed or truncated inventory, or no accessible online runner with every required label all make the check red. It never emits a green soft pass. Busy online runners remain eligible because GitHub can queue the licensed job until one becomes idle.
 
-### Upgrading the soft pass to a hard pass
+The `Unity CI Success` aggregate job runs with `always()` and is the required branch-protection check. It rejects a failed or cancelled preflight and rejects an unexpected skipped licensed job, so a runner outage cannot produce a green Unity check merely because dependent jobs were skipped.
 
-The default `secrets.GITHUB_TOKEN` cannot list runners under a repo-level scope strict enough to reflect the runner-group ACL, so the preflight falls back to a soft pass on most installations. To upgrade the soft-pass path to a hard-pass:
-
-1. Mint a fine-grained personal access token (or a GitHub App installation token) holding the repository-level "Administration: read" permission, scoped to `wallstop/unity-helpers` only. Do NOT use a classic PAT with `admin:org`, and do NOT use the fine-grained "Organization administration: read" permission: both grant org-wide visibility, which causes `gh api orgs/<org>/actions/runners` to return the entire org runner inventory regardless of any individual repository's runner-group ACL. That would let the preflight see runners as online and silently pass even when the post-transfer ACL is broken, which is exactly the pitfall this runbook addresses.
-2. Add the token as a repository secret named `RUNNER_AUDIT_PAT`.
-3. The Unity workflows already prefer `RUNNER_AUDIT_PAT` over `GITHUB_TOKEN` when set (`GH_TOKEN: ${{ secrets.RUNNER_AUDIT_PAT || secrets.GITHUB_TOKEN }}`) and query the repo-scoped endpoint. That endpoint enforces the runner-group ACL: if the repository does not have access to a runner via its group, the runner is invisible there, which is the live ACL state we want the preflight to detect. The preflight retains the same soft-pass behavior if the secret is absent, so this is opt-in.
-
-The rationale is deliberate: we want the upgrade token to FAIL when the ACL is misconfigured, not paper over it; that is why we use the repo-scoped "Administration: read" permission rather than any org admin scope. Without that property the hard-pass mode would be worse than the soft-pass mode it replaces.
-
-Because `administration` is not a valid `permissions:` key for the workflow-scoped `GITHUB_TOKEN`, the only way to grant the preflight read access to the runner inventory under a repo-level scope is to provision an external token (PAT or app installation token) via `RUNNER_AUDIT_PAT`. Without that, the preflight falls back to the soft-pass path, which is the design intent.
+The reader App must be installed for the organization and expose the organization secrets `BUILD_LOCK_READER_APP_ID` and `BUILD_LOCK_READER_APP_PRIVATE_KEY` to this repository. Its organization permission is Self-hosted runners: read. No PAT or repository-level environment is required.
 
 If the preflight passes but the matrix job still stays queued, the cause is more likely the dispatcher bug (see [GitHub Community Discussion #186811](https://github.com/orgs/community/discussions/186811)) than the access list. Use the recovery workflows in this repository: `.github/workflows/unstick-run.yml` for manual recovery of a single run, and `.github/workflows/stuck-job-watchdog.yml` for the automated 5-minute scan.
 
@@ -201,7 +193,7 @@ The Unity workflows expect the following repository (or organization) secrets. T
 
 - `UNITY_SERIAL`, `UNITY_EMAIL`, `UNITY_PASSWORD` — classic serial Unity activation (all three required together).
 - `BUILD_LOCK_APP_ID`, `BUILD_LOCK_APP_PRIVATE_KEY` — dedicated GitHub App credentials for the `wallstop-organization-builds` organization build lock (`Ambiguous-Interactive/ambiguous-organization-build-lock`); both are required together and should be provisioned as organization secrets with access to this repository.
+- `BUILD_LOCK_READER_APP_ID`, `BUILD_LOCK_READER_APP_PRIVATE_KEY` — read-only GitHub App credentials used by the hosted runner preflight; both are required together and should be provisioned as organization secrets with access to this repository.
 - `UNITY_ACCELERATOR_ENDPOINT` — optional; enables the Unity Accelerator cache namespace when set.
-- `RUNNER_AUDIT_PAT` — optional; upgrades the runner-preflight soft pass to a hard pass (see above).
 
 Provision the required Unity and build-lock credentials as organization secrets selected for this repository. The licensed workflows intentionally do not bind jobs to a per-repository environment, so trusted pull requests from branches in this repository validate automatically without an environment approval. Pull requests from forks remain ineligible for licensed jobs and do not receive these secrets.

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -1408,8 +1408,12 @@ try {
         Remove-Item -LiteralPath $bootstrapEnvDiagnostics -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
-if ($bootstrapEnvExitCode -ne 2) {
-    Write-Host "::error file=scripts/unity/bootstrap-windows-runner.ps1::UH_RUNNER_DISABLE_AUTO_BOOTSTRAP=1 must force direct bootstrap script execution into detect-only mode. Exit $bootstrapEnvExitCode. Output: $($bootstrapEnvOutput -join ' ')"
+$bootstrapEnvOutputText = $bootstrapEnvOutput -join ' '
+if (
+    $bootstrapEnvExitCode -notin @(0, 2) -or
+    $bootstrapEnvOutputText -notmatch 'UH_RUNNER_DISABLE_AUTO_BOOTSTRAP=1 -> forcing DetectOnly'
+) {
+    Write-Host "::error file=scripts/unity/bootstrap-windows-runner.ps1::UH_RUNNER_DISABLE_AUTO_BOOTSTRAP=1 must force direct bootstrap script execution into detect-only mode. Healthy hosts return 0 and hosts missing prerequisites return 2. Exit $bootstrapEnvExitCode. Output: $bootstrapEnvOutputText"
     $failed = $true
 } elseif ($VerboseOutput) {
     Write-Info "Checked direct bootstrap honors UH_RUNNER_DISABLE_AUTO_BOOTSTRAP=1."

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -8,8 +8,8 @@ param([switch]$VerboseOutput)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$buildLockActionCommit = '092fb0ddfc1ff13c684ac0e3c76d9b48ec3ee315'
-$buildLockActionVersion = 'v1.7.1'
+$buildLockActionCommit = 'c9d7e9feda64700c00374ffcbcc9dd93553c7054'
+$buildLockActionVersion = 'v1.8.1'
 
 function Write-Info($msg) {
     if ($VerboseOutput) { Write-Host "[test-unity-workflow-matrix-contract] $msg" -ForegroundColor Cyan }
@@ -412,6 +412,7 @@ function Test-UnityLockAppConfiguration {
 [string[]]$lines = Get-Content -LiteralPath $workflowPath
 [string]$workflowContent = $lines -join "`n"
 [string[]]$benchmarksWorkflowLines = Get-Content -LiteralPath $benchmarksWorkflowPath
+[string]$benchmarksWorkflowContent = $benchmarksWorkflowLines -join "`n"
 [string[]]$releaseWorkflowLines = Get-Content -LiteralPath $releaseWorkflowPath
 [string[]]$runnerBootstrapLines = Get-Content -LiteralPath $runnerBootstrapPath
 [string]$runnerBootstrapContent = Get-Content -LiteralPath $runnerBootstrapPath -Raw
@@ -1035,16 +1036,15 @@ if ($VerboseOutput) {
 
 $runnerPreflightJob = if ($runnerBootstrapJobTexts.ContainsKey('runner-preflight')) { $runnerBootstrapJobTexts['runner-preflight'] } else { '' }
 $bootstrapJob = if ($runnerBootstrapJobTexts.ContainsKey('bootstrap')) { $runnerBootstrapJobTexts['bootstrap'] } else { '' }
-$requiredLabelsPattern = '(?m)^\s+REQUIRED_LABELS:\s*"self-hosted,Windows,RAM-64GB,\$\{\{\s*inputs\.runner-label\s*\}\}"\s*$'
 $bootstrapRunsOnPattern = '(?m)^\s+runs-on:\s*\[self-hosted,\s*Windows,\s*RAM-64GB,\s*"\$\{\{\s*inputs\.runner-label\s*\}\}"\]\s*$'
-$stableRunnerLabelMatcher = 'select((($labels - ((.labels // []) | map(.name))) | length) == 0)'
-$brokenRunnerLabelMatcher = '($labels | all(. as $l | (.labels // [])'
+$runnerPreflightAction = "Ambiguous-Interactive/ambiguous-organization-build-lock/.github/actions/check-unity-runner-availability@$buildLockActionCommit"
+$readerAppCredentialsPattern = '(?ms)reader-app-id:\s*\$\{\{\s*secrets\.BUILD_LOCK_READER_APP_ID\s*\}\}.*reader-app-private-key:\s*\$\{\{\s*secrets\.BUILD_LOCK_READER_APP_PRIVATE_KEY\s*\}\}'
 $runnerBootstrapPinsRequestedMachine = (
     $runnerBootstrapJobTexts.ContainsKey('runner-preflight') -and
     $runnerBootstrapJobTexts.ContainsKey('bootstrap') -and
-    $runnerPreflightJob -match $requiredLabelsPattern -and
-    $runnerPreflightJob.Contains($stableRunnerLabelMatcher) -and
-    -not $runnerPreflightJob.Contains($brokenRunnerLabelMatcher) -and
+    $runnerPreflightJob.Contains("uses: $runnerPreflightAction # $buildLockActionVersion") -and
+    $runnerPreflightJob -match $readerAppCredentialsPattern -and
+    $runnerPreflightJob.Contains('required-label-sets: ''[["self-hosted","Windows","RAM-64GB","${{ inputs.runner-label }}"]]''') -and
     $bootstrapJob -match $bootstrapRunsOnPattern -and
     $bootstrapJob.Contains('custom ''$requested'' label') -and
     $actionlintContent.Contains('- DAD-MACHINE') -and
@@ -1061,19 +1061,46 @@ if (-not $runnerBootstrapPinsRequestedMachine) {
 
 $unityTestsRunnerPreflightJob = if ($jobTexts.ContainsKey('runner-preflight')) { $jobTexts['runner-preflight'] } else { '' }
 $benchmarksRunnerPreflightJob = if ($benchmarksJobTexts.ContainsKey('runner-preflight')) { $benchmarksJobTexts['runner-preflight'] } else { '' }
-$unityWorkflowRunnerPreflightsUseStableMatcher = (
+$unityWorkflowRunnerPreflightsFailClosed = (
     $jobTexts.ContainsKey('runner-preflight') -and
     $benchmarksJobTexts.ContainsKey('runner-preflight') -and
-    $unityTestsRunnerPreflightJob.Contains($stableRunnerLabelMatcher) -and
-    $benchmarksRunnerPreflightJob.Contains($stableRunnerLabelMatcher) -and
-    -not $unityTestsRunnerPreflightJob.Contains($brokenRunnerLabelMatcher) -and
-    -not $benchmarksRunnerPreflightJob.Contains($brokenRunnerLabelMatcher)
+    $unityTestsRunnerPreflightJob.Contains("uses: $runnerPreflightAction # $buildLockActionVersion") -and
+    $benchmarksRunnerPreflightJob.Contains("uses: $runnerPreflightAction # $buildLockActionVersion") -and
+    $unityTestsRunnerPreflightJob -match $readerAppCredentialsPattern -and
+    $benchmarksRunnerPreflightJob -match $readerAppCredentialsPattern -and
+    $unityTestsRunnerPreflightJob.Contains('required-label-sets: ''[["self-hosted","Windows","RAM-64GB"]]''') -and
+    $benchmarksRunnerPreflightJob.Contains('required-label-sets: ''[["self-hosted","Windows","RAM-64GB"]]''') -and
+    -not $workflowContent.Contains('RUNNER_AUDIT_PAT') -and
+    -not $benchmarksWorkflowContent.Contains('RUNNER_AUDIT_PAT') -and
+    -not $runnerBootstrapContent.Contains('RUNNER_AUDIT_PAT') -and
+    -not $workflowContent.Contains('Soft pass: skipping runner inventory check.') -and
+    -not $benchmarksWorkflowContent.Contains('Soft pass: skipping runner inventory check.') -and
+    -not $runnerBootstrapContent.Contains('Soft pass: skipping runner inventory check.')
 )
-if (-not $unityWorkflowRunnerPreflightsUseStableMatcher) {
-    Write-Host "::error file=.github/workflows/unity-tests.yml::Unity workflow runner-preflight label matching must use the set-difference matcher from runner-bootstrap.yml so visible runner inventories do not crash jq by treating label strings as runner objects. Keep .github/workflows/unity-benchmarks.yml in sync."
+if (-not $unityWorkflowRunnerPreflightsFailClosed) {
+    Write-Host "::error file=.github/workflows/unity-tests.yml::Every self-hosted Unity runner preflight must use the pinned reader-App action, request the exact runs-on labels, and fail closed without PAT or soft-pass fallbacks."
     $failed = $true
 } elseif ($VerboseOutput) {
-    Write-Info "Checked Unity workflow runner-preflight label matchers use the stable set-difference form."
+    Write-Info "Checked Unity workflow runner preflights use the fail-closed reader-App action."
+}
+
+$unityCiSuccessJob = if ($jobTexts.ContainsKey('unity-ci-success')) { $jobTexts['unity-ci-success'] } else { '' }
+$unityCiSuccessContract = (
+    $jobTexts.ContainsKey('unity-ci-success') -and
+    $unityCiSuccessJob -match '(?m)^\s+name:\s*Unity CI Success\s*$' -and
+    $unityCiSuccessJob -match '(?m)^\s+if:\s*\$\{\{\s*always\(\)\s*\}\}\s*$' -and
+    $unityCiSuccessJob.Contains('needs.runner-preflight.result') -and
+    $unityCiSuccessJob.Contains('needs.unity-tests.result') -and
+    $unityCiSuccessJob.Contains('needs.unity-tests-standalone.result') -and
+    $unityCiSuccessJob.Contains('needs.unity-tests-single-threaded.result') -and
+    $unityCiSuccessJob.Contains('needs.unitypackage-smoke.result') -and
+    $unityCiSuccessJob.Contains('Unexpected Unity CI job result')
+)
+if (-not $unityCiSuccessContract) {
+    Write-Host "::error file=.github/workflows/unity-tests.yml::Unity CI must end in an always-reporting Unity CI Success job that rejects runner-preflight failures and unexpected skipped licensed jobs."
+    $failed = $true
+} elseif ($VerboseOutput) {
+    Write-Info "Checked Unity CI has an always-reporting fail-closed aggregate job."
 }
 
 function Get-UnityWorkflowStepText {

--- a/scripts/tests/test-unity-workflow-matrix-contract.ps1
+++ b/scripts/tests/test-unity-workflow-matrix-contract.ps1
@@ -8,8 +8,8 @@ param([switch]$VerboseOutput)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
-$buildLockActionCommit = 'c9d7e9feda64700c00374ffcbcc9dd93553c7054'
-$buildLockActionVersion = 'v1.8.1'
+$buildLockActionCommit = 'a8d43dd87a938f1b3417fd8a9310354bf38e2fd1'
+$buildLockActionVersion = 'v1.8.2'
 
 function Write-Info($msg) {
     if ($VerboseOutput) { Write-Host "[test-unity-workflow-matrix-contract] $msg" -ForegroundColor Cyan }


### PR DESCRIPTION
## Summary
- replace PAT/GITHUB_TOKEN soft-pass runner probes with the v1.8.1 reader-App preflight pinned to c9d7e9feda64700c00374ffcbcc9dd93553c7054
- require repository-visible online Windows Unity runners before tests, benchmarks, and runner maintenance
- add an always-reporting Unity CI Success aggregate that rejects preflight failure and unexpected skipped licensed jobs
- remove the obsolete RUNNER_AUDIT_PAT runbook contract
- make the bootstrap detect-only fixture portable to both healthy and missing-prerequisite hosts

## Verification
- focused Unity workflow contract: pass
- actionlint on changed self-hosted workflows: pass
- actionlint YAML/action semantics on release workflow: pass
- Prettier and git diff checks: pass
- npm run agent:preflight:fix: pass
- npm run validate:prepush: reaches the existing test:gitignore-docs baseline failure (5 fixture failures reproduced unchanged on untouched checkout); all preceding gates pass

## Live canary
This same-repository PR intentionally triggers licensed Unity validation without an environment approval. The hosted runner preflight must authenticate with the organization reader App, see only runner groups accessible to this repository, and go red rather than soft-pass if inventory or runners are unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gate all licensed Unity CI on new org reader secrets and a stricter preflight; missing credentials or App misconfiguration will fail workflows that previously soft-passed, though the aggregate job reduces false greens from skipped matrix jobs.
> 
> **Overview**
> Unity CI **fails closed** on runner availability instead of soft-passing when inventory APIs are unreachable. Inline `gh api` / `RUNNER_AUDIT_PAT` preflight scripts in **unity-tests**, **unity-benchmarks**, and **runner-bootstrap** are replaced by the pinned **`check-unity-runner-availability`** action (org reader App: `BUILD_LOCK_READER_APP_ID` / `BUILD_LOCK_READER_APP_PRIVATE_KEY`) with label sets aligned to each workflow’s `runs-on`.
> 
> **`ambiguous-organization-build-lock`** acquire/release steps move from **v1.7.1** to **v1.8.2** across release, benchmarks, and tests.
> 
> A new **`unity-ci-success`** job (`always()`, branch-protection target) aggregates licensed job outcomes and fails on preflight failure/cancel or unexpected skips when Unity work should have run.
> 
> The runner runbook drops the **`RUNNER_AUDIT_PAT`** contract and documents reader-App preflight plus **`Unity CI Success`**. Workflow contract tests enforce the new pins, reader secrets, fail-closed behavior, and aggregate job; the bootstrap **`UH_RUNNER_DISABLE_AUTO_BOOTSTRAP`** fixture accepts exit **0** or **2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58f1f5b557ccef1a12900018b3818d9e203cbd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->